### PR TITLE
Fix update script execution with spaces in temp paths

### DIFF
--- a/ClaudeUsageTray/Services/UpdateService.cs
+++ b/ClaudeUsageTray/Services/UpdateService.cs
@@ -87,19 +87,22 @@ public class UpdateService
         response.EnsureSuccessStatusCode();
 
         var totalBytes = response.Content.Headers.ContentLength ?? 0;
-        using var srcStream  = await response.Content.ReadAsStreamAsync();
-        using var destStream = new FileStream(newExePath, FileMode.Create, FileAccess.Write, FileShare.None, 81920, useAsync: true);
+        using var srcStream = await response.Content.ReadAsStreamAsync();
 
-        var buffer = new byte[81920];
-        long downloaded = 0;
-        int  read;
-        while ((read = await srcStream.ReadAsync(buffer)) > 0)
         {
-            await destStream.WriteAsync(buffer.AsMemory(0, read));
-            downloaded += read;
-            if (totalBytes > 0)
-                progress?.Report((int)(downloaded * 100 / totalBytes));
-        }
+            using var destStream = new FileStream(newExePath, FileMode.Create, FileAccess.Write, FileShare.None, 81920, useAsync: true);
+
+            var buffer = new byte[81920];
+            long downloaded = 0;
+            int  read;
+            while ((read = await srcStream.ReadAsync(buffer)) > 0)
+            {
+                await destStream.WriteAsync(buffer.AsMemory(0, read));
+                downloaded += read;
+                if (totalBytes > 0)
+                    progress?.Report((int)(downloaded * 100 / totalBytes));
+            }
+        } // destStream closed here — before SHA256 verification and before batch script
 
         // SHA256 verification — try to download sha256 file and verify
         if (!string.IsNullOrEmpty(sha256Url))
@@ -134,15 +137,22 @@ public class UpdateService
             @echo off
             timeout /t 2 /nobreak >nul
             copy /y "{newExePath}" "{currentExe}"
+            if errorlevel 1 (
+                echo [%date% %time%] copy failed: {newExePath} -^> {currentExe} >> "%TEMP%\claude_update_error.log"
+                exit /b 1
+            )
             start "" "{currentExe}"
-            del "{newExePath}"
+            del "{newExePath}" 2>nul
             del "%~f0"
             """;
         await File.WriteAllTextAsync(scriptPath, script);
 
-        Process.Start(new ProcessStartInfo("cmd.exe", $"/c \"{scriptPath}\"")
+        // Double-quote the script path inside /c "..." so cmd.exe correctly handles
+        // paths that contain spaces (e.g. username with a space in %TEMP%).
+        // Without double-quoting: cmd.exe strips the outer quotes then parses on spaces,
+        // causing silent failure when the TEMP path contains a space.
+        Process.Start(new ProcessStartInfo("cmd.exe", $"/c \"\"{scriptPath}\"\"")
         {
-            WindowStyle = ProcessWindowStyle.Hidden,
             CreateNoWindow = true
         });
 


### PR DESCRIPTION
## Summary
This PR fixes critical issues in the update process that could cause silent failures when the user's temp directory contains spaces in the path.

## Key Changes
- **Moved `destStream` disposal**: Wrapped the file download logic in a scope to ensure the destination file stream is closed before the batch script attempts to copy/delete it. This prevents file locking issues during the update process.

- **Fixed batch script quoting**: Changed the cmd.exe invocation from `/c "{scriptPath}"` to `/c ""{scriptPath}""` to properly handle temp paths containing spaces. Without the inner quotes, cmd.exe strips the outer quotes and parses on spaces, causing the script path to be truncated and the update to fail silently.

- **Added error handling in batch script**: 
  - Added error level check after the copy operation to detect and log copy failures
  - Changed `del "{newExePath}"` to `del "{newExePath}" 2>nul` to suppress errors if the file is already deleted

- **Removed unnecessary ProcessStartInfo property**: Removed `WindowStyle = ProcessWindowStyle.Hidden` as `CreateNoWindow = true` already hides the window.

- **Added explanatory comment**: Documented the double-quoting requirement for proper cmd.exe argument parsing.

## Implementation Details
The core issue was that when a user's `%TEMP%` directory path contains spaces (e.g., `C:\Users\John Doe\AppData\Local\Temp`), the batch script path would be incorrectly parsed by cmd.exe, causing the update to fail without any visible error. The fix ensures proper quoting so cmd.exe receives the complete path as a single argument.

https://claude.ai/code/session_01FRyA5bcsMEtVJsPfr1rMPf