### PR TITLE
i18n: 하드코딩된 한국어 문자열 다국어 처리

### DIFF
--- a/ClaudeUsageTray/Services/LocalizationService.cs
+++ b/ClaudeUsageTray/Services/LocalizationService.cs
@@ -511,6 +511,39 @@ public static class Loc
         _ => $"{used:N0} credits used (no limit set)"
     };
 
+    // Chart toggle labels
+    public static string SevenDayToggle => Lang switch
+    {
+        "ko" => "7일",
+        "zh" => "7天",
+        "ja" => "7日",
+        _ => "7d"
+    };
+
+    public static string TodayToggle => Lang switch
+    {
+        "ko" => "오늘",
+        "zh" => "今日",
+        "ja" => "今日",
+        _ => "Today"
+    };
+
+    public static string ExportCsvTooltip => Lang switch
+    {
+        "ko" => "CSV로 내보내기",
+        "zh" => "导出为 CSV",
+        "ja" => "CSV に書き出す",
+        _ => "Export to CSV"
+    };
+
+    public static string Disclaimer => Lang switch
+    {
+        "ko" => "이 앱은 참고용 도구입니다. 표시되는 수치는 공식 수치와 다를 수 있으며, 요금·과금 관련 문제에 대해 개발자는 책임을 지지 않습니다. 정확한 사용량은 Anthropic 공식 콘솔에서 확인하세요.",
+        "zh" => "本应用仅供参考。显示数值可能与官方数据不同，开发者不对任何计费问题承担责任。请通过 Anthropic 官方控制台确认准确用量。",
+        "ja" => "このアプリは参考ツールです。表示される数値は公式データと異なる場合があります。料金関連の問題について開発者は責任を負いません。正確な使用量は Anthropic の公式コンソールで確認してください。",
+        _ => "This app is a reference tool only. Displayed values may differ from official figures. The developer is not liable for any billing issues. Please verify accurate usage on the official Anthropic console."
+    };
+
     public static string ApiError(string msg) => Lang switch
     {
         "ko" => $"API 오류: {msg}",

--- a/ClaudeUsageTray/Views/SettingsWindow.xaml
+++ b/ClaudeUsageTray/Views/SettingsWindow.xaml
@@ -186,8 +186,7 @@
                 </StackPanel>
 
                 <!-- Disclaimer -->
-                <TextBlock Margin="16,4,16,14" TextWrapping="Wrap" FontSize="10" Foreground="#3D4266"
-                           Text="이 앱은 참고용 도구입니다. 표시되는 수치는 공식 수치와 다를 수 있으며, 요금·과금 관련 문제에 대해 개발자는 책임을 지지 않습니다. 정확한 사용량은 Anthropic 공식 콘솔에서 확인하세요."/>
+                <TextBlock x:Name="LblDisclaimer" Margin="16,4,16,14" TextWrapping="Wrap" FontSize="10" Foreground="#3D4266"/>
 
             </StackPanel>
         </Border>

--- a/ClaudeUsageTray/Views/SettingsWindow.xaml.cs
+++ b/ClaudeUsageTray/Views/SettingsWindow.xaml.cs
@@ -66,6 +66,7 @@ public partial class SettingsWindow : Window
         LblNtfyTopic.Text                   = Loc.NtfyTopic;
         LblNtfyHint.Text                    = Loc.NtfyPlaceholder;
         LblNtfySecurityWarning.Text         = Loc.NtfySecurityWarning;
+        LblDisclaimer.Text                  = Loc.Disclaimer;
     }
 
     private void LoadValues()

--- a/ClaudeUsageTray/Views/UsagePopup.xaml
+++ b/ClaudeUsageTray/Views/UsagePopup.xaml
@@ -365,7 +365,7 @@
                                 <StackPanel Orientation="Horizontal">
                                     <Button x:Name="Toggle7DayBtn" Click="Toggle7DayBtn_Click"
                                             BorderThickness="0" Cursor="Hand" Padding="6,2">
-                                        <TextBlock x:Name="Toggle7DayText" Text="7일" FontSize="10"/>
+                                        <TextBlock x:Name="Toggle7DayText" FontSize="10"/>
                                         <Button.Style>
                                             <Style TargetType="Button">
                                                 <Setter Property="Background" Value="#2D2F45"/>
@@ -383,7 +383,7 @@
                                     </Button>
                                     <Button x:Name="ToggleHourlyBtn" Click="ToggleHourlyBtn_Click"
                                             BorderThickness="0" Cursor="Hand" Padding="6,2">
-                                        <TextBlock x:Name="ToggleHourlyText" Text="오늘" FontSize="10"/>
+                                        <TextBlock x:Name="ToggleHourlyText" FontSize="10"/>
                                         <Button.Style>
                                             <Style TargetType="Button">
                                                 <Setter Property="Background" Value="Transparent"/>
@@ -402,8 +402,8 @@
                                 </StackPanel>
                             </Border>
                             <!-- CSV export -->
-                            <Button Background="Transparent" BorderThickness="0"
-                                    Cursor="Hand" Click="ExportCsvBtn_Click" ToolTip="CSV로 내보내기">
+                            <Button x:Name="CsvExportBtn" Background="Transparent" BorderThickness="0"
+                                    Cursor="Hand" Click="ExportCsvBtn_Click">
                                 <TextBlock Text="↓ CSV" Foreground="#3D4266" FontSize="10"/>
                                 <Button.Style>
                                     <Style TargetType="Button">

--- a/ClaudeUsageTray/Views/UsagePopup.xaml.cs
+++ b/ClaudeUsageTray/Views/UsagePopup.xaml.cs
@@ -35,6 +35,7 @@ public partial class UsagePopup : Window
         vm.PropertyChanged += OnVmPropertyChanged;
         Loaded += (_, _) => RefreshChart();
         UpdateToggleStyle();
+        CsvExportBtn.ToolTip = Loc.ExportCsvTooltip;
     }
 
     private void OnVmPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -66,8 +67,10 @@ public partial class UsagePopup : Window
 
         Toggle7DayBtn.Background   = _showHourly ? inactiveBg : activeBg;
         Toggle7DayText.Foreground  = _showHourly ? inactiveFg : activeFg;
+        Toggle7DayText.Text        = Loc.SevenDayToggle;
         ToggleHourlyBtn.Background = _showHourly ? activeBg : inactiveBg;
         ToggleHourlyText.Foreground = _showHourly ? activeFg : inactiveFg;
+        ToggleHourlyText.Text      = Loc.TodayToggle;
 
         ChartTitleLabel.Text = _showHourly
             ? Services.Loc.HourlyChartTitle


### PR DESCRIPTION
## 변경 내용

XAML 및 코드에 하드코딩된 한국어 전용 문자열 4곳을 `LocalizationService`로 이전했습니다.

### 문제
| 위치 | 하드코딩 값 |
|------|------------|
| `UsagePopup.xaml` Toggle7DayText | `"7일"` |
| `UsagePopup.xaml` ToggleHourlyText | `"오늘"` |
| `UsagePopup.xaml` CSV 버튼 ToolTip | `"CSV로 내보내기"` |
| `SettingsWindow.xaml` 면책조항 | 한국어 전문 하드코딩 |

한국어 시스템에서는 정상 동작하지만, 영어/중국어/일본어 사용자에게는 한국어가 그대로 표시되는 버그였습니다.

### 수정

- **`LocalizationService.cs`**: 4개 문자열 추가 (ko/zh/ja/en 전부)
  - `SevenDayToggle` — "7일" / "7天" / "7日" / "7d"
  - `TodayToggle` — "오늘" / "今日" / "今日" / "Today"
  - `ExportCsvTooltip` — "CSV로 내보내기" / ... / "Export to CSV"
  - `Disclaimer` — 면책조항 전문 4개 언어

- **`UsagePopup.xaml`**: Toggle 버튼 `Text` 하드코딩 제거, CSV 버튼 툴팁 제거 + `x:Name` 추가
- **`UsagePopup.xaml.cs`**: `UpdateToggleStyle()`에서 `Loc.SevenDayToggle` / `Loc.TodayToggle` 적용, 생성자에서 CSV 툴팁 적용
- **`SettingsWindow.xaml`**: 면책조항 하드코딩 제거 → `x:Name="LblDisclaimer"` 추가
- **`SettingsWindow.xaml.cs`**: `ApplyLocalization()`에 `Loc.Disclaimer` 추가

https://claude.ai/code/session_01FDMqiK7HHzPKMJqiV1v1Sd