### PR TITLE
fix: 오늘의 토큰 과소 집계 및 빈 토큰 오진 수정 (v1.36.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 모든 주요 변경 사항을 이 파일에 기록합니다.
 [Keep a Changelog](https://keepachangelog.com/ko/1.0.0/) 형식을 따릅니다.
 
+## [1.36.1] - 2026-08-04
+
+<!-- ko -->
+### 수정
+- **오늘의 토큰이 실제 사용량보다 훨씬 적게 집계되던 문제** — 세션 파일이 계속 기록되는 동안에는 "직전 조회 이후 새로 쓰인 부분"만 더해 오늘 총량으로 표시하고, 그 값을 그대로 히스토리에 덮어썼습니다. 작업 중일수록 어긋나서 실측에서는 캐시 읽기가 실제의 1/3 수준까지 떨어졌고, 7일 추이 차트와 비용 추정치도 함께 낮게 나왔습니다. 이제 오늘 기록이 있을 수 있는 파일만 골라 매번 전체를 다시 읽어, 몇 번을 새로고침해도 같은 총량이 나옵니다. 시간대별 차트가 경로에 따라 캐시 토큰을 빼먹던 문제도 함께 고쳤습니다.
+- **로그인이 풀렸는데 "API 응답 대기 중"으로만 표시되던 문제** — Claude Code 가 로그아웃하면서 액세스 토큰을 빈 값으로 남기는 경우가 있는데, 앱이 이를 토큰이 있는 것으로 보고 인증 없이 요청을 보냈습니다. 그 응답(429)을 일시적 제한으로 오해해 "잠시 후 자동 재시도" 안내만 반복하며 사용량이 0% 로 고정됐습니다. 이제 빈 토큰을 로그인 필요 상태로 인식하고 로그인 안내를 표시합니다.
+- **할당량을 못 받아온 상태를 "0% 사용 · 잔량 100%"로 표시하던 문제** — 한 번도 조회에 성공하지 못한 상태에서 여유가 가득한 것처럼 보였습니다. 이제 조회 전에는 "—"와 안내 문구로 구분해 표시합니다.
+
+### 개선
+- 트랜스크립트 스캔을 백그라운드 스레드로 옮겨, 새로고침 중 창이 잠깐 멈추던 현상을 없앴습니다.
+<!-- /ko -->
+
+<!-- en -->
+### Fixed
+- **Today's token count was far lower than actual usage** — While a session file was still being written, the app summed only the bytes added since the previous scan, showed that as the day's total, and overwrote history with it. The more you worked, the further it drifted — measured on real data, cache-read tokens fell to about a third of actual, dragging the 7-day chart and cost estimate down with them. It now re-reads every file that could hold today's entries in full, so repeated refreshes produce the same total. The hourly chart, which dropped cache tokens on one of the two code paths, is consistent again.
+- **A signed-out state showed only "waiting for API response"** — Claude Code can leave the access token as an empty value when signing out. The app treated that as a real token, sent an unauthenticated request, and read the resulting 429 as a temporary limit — so it kept showing "retrying automatically" with usage stuck at 0%. An empty token is now recognized as signed-out and shows sign-in guidance.
+- **An unfetched quota was shown as "0% used · 100% remaining"** — Before any successful fetch, the app looked like it had full headroom. It now shows "—" with an explanatory line until a quota is actually retrieved.
+
+### Improved
+- Transcript scanning moved off the UI thread, removing a brief freeze during refresh.
+<!-- /en -->
+
 ## [1.36.0] - 2026-07-23
 
 <!-- ko -->

--- a/ClaudeUsageTray.Tests/Services/CredentialServiceTests.cs
+++ b/ClaudeUsageTray.Tests/Services/CredentialServiceTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using ClaudeUsageTray.Services;
+using Xunit;
+
+namespace ClaudeUsageTray.Tests.Services;
+
+public class CredentialServiceTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _path;
+
+    public CredentialServiceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cut-credentials-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        _path = Path.Combine(_dir, ".credentials.json");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// 회귀 방지: Claude Code 가 로그아웃하면서 accessToken 만 빈 문자열로 남기는 경우가 있다.
+    /// 이걸 토큰으로 취급하면 인증 없는 요청이 나가고 429 가 돌아와, 앱이 "로그인 필요"가 아니라
+    /// "일시적 제한"으로 오진한 채 0% 를 계속 보여줬다.
+    /// </summary>
+    [Fact]
+    public async Task GetValidAccessTokenAsync_ReturnsNull_WhenTokenIsEmptyString()
+    {
+        Write("""
+        {
+          "claudeAiOauth": {
+            "accessToken": "",
+            "refreshToken": "",
+            "expiresAt": 0,
+            "scopes": ["user:inference", "user:profile"],
+            "subscriptionType": "max"
+          }
+        }
+        """);
+
+        using var service = new CredentialService(_path);
+
+        Assert.Null(await service.GetValidAccessTokenAsync());
+        Assert.Null(service.GetAccessToken());
+    }
+
+    [Fact]
+    public async Task GetValidAccessTokenAsync_ReturnsNull_WhenTokenIsWhitespace()
+    {
+        Write("""
+        { "claudeAiOauth": { "accessToken": "   ", "refreshToken": "   ", "expiresAt": 0 } }
+        """);
+
+        using var service = new CredentialService(_path);
+
+        Assert.Null(await service.GetValidAccessTokenAsync());
+    }
+
+    [Fact]
+    public async Task GetValidAccessTokenAsync_ReturnsToken_WhenStillValid()
+    {
+        var expiresAt = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeMilliseconds();
+        Write($$"""
+        { "claudeAiOauth": { "accessToken": "sk-test-token", "refreshToken": "rt", "expiresAt": {{expiresAt}} } }
+        """);
+
+        using var service = new CredentialService(_path);
+
+        Assert.Equal("sk-test-token", await service.GetValidAccessTokenAsync());
+    }
+
+    [Fact]
+    public async Task GetValidAccessTokenAsync_ReturnsNull_WhenFileMissing()
+    {
+        using var service = new CredentialService(_path);
+
+        Assert.Null(await service.GetValidAccessTokenAsync());
+    }
+
+    private void Write(string json) => File.WriteAllText(_path, json);
+}

--- a/ClaudeUsageTray.Tests/Services/SessionMonitorTests.cs
+++ b/ClaudeUsageTray.Tests/Services/SessionMonitorTests.cs
@@ -1,15 +1,174 @@
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using ClaudeUsageTray.Services;
 using Xunit;
 
 namespace ClaudeUsageTray.Tests.Services;
 
-public class SessionMonitorTests
+public class SessionMonitorTests : IDisposable
 {
+    private readonly string _root;
+
+    public SessionMonitorTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "cut-session-monitor-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
     [Fact]
     public void CanInstantiate()
     {
-        // Verify the SessionMonitor can be instantiated
-        var monitor = new ClaudeUsageTray.Services.SessionMonitor();
+        var monitor = new SessionMonitor();
         Assert.NotNull(monitor);
+    }
+
+    [Fact]
+    public void ScanTodayUsage_SumsTodayEntries()
+    {
+        WriteSession("proj-a/a.jsonl",
+            AssistantLine(Today(9), input: 10, output: 20, cacheRead: 300, cacheWrite: 40),
+            AssistantLine(Today(10), input: 1, output: 2, cacheRead: 3, cacheWrite: 4));
+
+        var stats = new SessionMonitor(_root).ScanTodayUsage();
+
+        Assert.Equal(11, stats.TotalInputTokens);
+        Assert.Equal(22, stats.TotalOutputTokens);
+        Assert.Equal(303, stats.TotalCacheReadTokens);
+        Assert.Equal(44, stats.TotalCacheWriteTokens);
+        Assert.Equal(1, stats.SessionCount);
+    }
+
+    /// <summary>
+    /// 회귀 방지: 증분 스캔 시절엔 두 번째 호출이 "직전 스캔 이후 델타"만 돌려줘서
+    /// 오늘 총량이 실제의 일부로 기록됐다. 몇 번을 호출하든 같은 총량이어야 한다.
+    /// </summary>
+    [Fact]
+    public void ScanTodayUsage_IsIdempotent_AcrossRepeatedScans()
+    {
+        WriteSession("proj-a/a.jsonl",
+            AssistantLine(Today(9), input: 10, output: 20, cacheRead: 300, cacheWrite: 40));
+
+        var monitor = new SessionMonitor(_root);
+        var first = monitor.ScanTodayUsage();
+        var second = monitor.ScanTodayUsage();
+        var third = monitor.ScanTodayUsage();
+
+        Assert.Equal(first.GrandTotal, second.GrandTotal);
+        Assert.Equal(first.GrandTotal, third.GrandTotal);
+        Assert.Equal(370, third.GrandTotal);
+    }
+
+    /// <summary>
+    /// 회귀 방지: 스캔 사이에 파일이 커지면 새로 붙은 부분만이 아니라 그날 총량이 나와야 한다.
+    /// (활성 세션이 계속 기록 중일 때 실제로 사용량이 1/3 수준으로 줄어들던 경로)
+    /// </summary>
+    [Fact]
+    public void ScanTodayUsage_ReturnsDayTotal_WhenFileGrowsBetweenScans()
+    {
+        var path = WriteSession("proj-a/a.jsonl",
+            AssistantLine(Today(9), input: 100, output: 200, cacheRead: 3000, cacheWrite: 400));
+
+        var monitor = new SessionMonitor(_root);
+        var before = monitor.ScanTodayUsage();
+        Assert.Equal(3700, before.GrandTotal);
+
+        File.AppendAllText(path,
+            AssistantLine(Today(11), input: 1, output: 2, cacheRead: 30, cacheWrite: 4) + Environment.NewLine,
+            new UTF8Encoding(false));
+
+        var after = monitor.ScanTodayUsage();
+
+        Assert.Equal(3737, after.GrandTotal);
+        Assert.Equal(101, after.TotalInputTokens);
+    }
+
+    [Fact]
+    public void ScanTodayUsage_ExcludesEntriesBeforeToday()
+    {
+        WriteSession("proj-a/a.jsonl",
+            AssistantLine(Today(9).AddDays(-1), input: 999, output: 999, cacheRead: 999, cacheWrite: 999),
+            AssistantLine(Today(9), input: 1, output: 2, cacheRead: 3, cacheWrite: 4));
+
+        var stats = new SessionMonitor(_root).ScanTodayUsage();
+
+        Assert.Equal(10, stats.GrandTotal);
+    }
+
+    [Fact]
+    public void ScanTodayUsage_AggregatesAcrossProjectDirectories()
+    {
+        WriteSession("proj-a/a.jsonl", AssistantLine(Today(9), input: 1, output: 0, cacheRead: 0, cacheWrite: 0));
+        WriteSession("proj-b/nested/b.jsonl", AssistantLine(Today(9), input: 2, output: 0, cacheRead: 0, cacheWrite: 0));
+
+        var stats = new SessionMonitor(_root).ScanTodayUsage();
+
+        Assert.Equal(3, stats.TotalInputTokens);
+        Assert.Equal(2, stats.SessionCount);
+    }
+
+    /// <summary>시간대별 집계는 캐시 토큰까지 포함한다 (증분 경로는 input+output 만 더해 값이 달라졌다).</summary>
+    [Fact]
+    public void ScanTodayUsage_HourlyTokensIncludeCacheTokens()
+    {
+        WriteSession("proj-a/a.jsonl",
+            AssistantLine(Today(9), input: 1, output: 2, cacheRead: 30, cacheWrite: 4));
+
+        var stats = new SessionMonitor(_root).ScanTodayUsage();
+
+        Assert.Equal(37, stats.HourlyTokens[9]);
+        Assert.Equal(0, stats.HourlyTokens.Where((_, h) => h != 9).Sum());
+    }
+
+    [Fact]
+    public void ScanTodayUsage_IgnoresMalformedLinesAndNonAssistantEntries()
+    {
+        WriteSession("proj-a/a.jsonl",
+            "{ not json",
+            "{\"type\":\"user\",\"timestamp\":\"" + Iso(Today(9)) + "\"}",
+            AssistantLine(Today(9), input: 5, output: 0, cacheRead: 0, cacheWrite: 0));
+
+        var stats = new SessionMonitor(_root).ScanTodayUsage();
+
+        Assert.Equal(5, stats.TotalInputTokens);
+        Assert.Equal(1, stats.SessionCount);
+    }
+
+    [Fact]
+    public void ScanTodayUsage_ReturnsEmpty_WhenRootMissing()
+    {
+        var stats = new SessionMonitor(Path.Combine(_root, "does-not-exist")).ScanTodayUsage();
+
+        Assert.Equal(0, stats.GrandTotal);
+        Assert.Equal(0, stats.SessionCount);
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static DateTime Today(int hour) => DateTime.Today.AddHours(hour);
+
+    private static string Iso(DateTime local) =>
+        new DateTimeOffset(local).ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'", CultureInfo.InvariantCulture);
+
+    private static string AssistantLine(DateTime localTimestamp, long input, long output, long cacheRead, long cacheWrite) =>
+        $"{{\"type\":\"assistant\",\"timestamp\":\"{Iso(localTimestamp)}\",\"message\":{{\"usage\":{{" +
+        $"\"input_tokens\":{input},\"output_tokens\":{output}," +
+        $"\"cache_read_input_tokens\":{cacheRead},\"cache_creation_input_tokens\":{cacheWrite}}}}}}}";
+
+    private string WriteSession(string relativePath, params string[] lines)
+    {
+        var path = Path.Combine(_root, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllLines(path, lines, new UTF8Encoding(false));
+        return path;
     }
 }

--- a/ClaudeUsageTray.Tests/ViewModels/ClaudeViewModelQuotaLabelTests.cs
+++ b/ClaudeUsageTray.Tests/ViewModels/ClaudeViewModelQuotaLabelTests.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using ClaudeUsageTray.Services;
+using ClaudeUsageTray.ViewModels;
+using Xunit;
+
+namespace ClaudeUsageTray.Tests.ViewModels;
+
+public class ClaudeViewModelQuotaLabelTests
+{
+    /// <summary>
+    /// 회귀 방지: 조회에 한 번도 성공하지 못한 상태에서 퍼센트 0 을 "0%"로 그리면
+    /// "여유 100%"라는 반대 의미가 전달된다. 이 상태는 "—"여야 한다.
+    /// </summary>
+    [Fact]
+    public void PercentLabels_ShowDash_UntilQuotaHasBeenFetched()
+    {
+        var vm = new ClaudeViewModel();
+
+        Assert.False(vm.HasQuotaData);
+        Assert.Equal("—", vm.ShortPercentLabel);
+        Assert.Equal("—", vm.LongPercentLabel);
+    }
+
+    [Fact]
+    public void PercentLabels_ShowPercent_OnceQuotaIsKnown()
+    {
+        var vm = new ClaudeViewModel { HasQuotaData = true, ShortPercent = 0.37, LongPercent = 0.05 };
+
+        Assert.Equal(0.37.ToString("P0"), vm.ShortPercentLabel);
+        Assert.Equal(0.05.ToString("P0"), vm.LongPercentLabel);
+    }
+
+    /// <summary>실제 0% 사용은 "—"가 아니라 "0%"로 나와야 한다 (미조회와 구분).</summary>
+    [Fact]
+    public void PercentLabels_ShowZeroPercent_WhenQuotaIsKnownAndZero()
+    {
+        var vm = new ClaudeViewModel { HasQuotaData = true, ShortPercent = 0 };
+
+        Assert.Equal(0d.ToString("P0"), vm.ShortPercentLabel);
+    }
+
+    [Fact]
+    public void PercentLabels_RaiseChangeNotifications()
+    {
+        var vm = new ClaudeViewModel();
+        var changed = new List<string?>();
+        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        vm.ShortPercent = 0.5;
+        vm.LongPercent = 0.2;
+        vm.HasQuotaData = true;
+
+        Assert.Contains(nameof(ClaudeViewModel.ShortPercentLabel), changed);
+        Assert.Contains(nameof(ClaudeViewModel.LongPercentLabel), changed);
+        // HasQuotaData 전환 하나로 두 라벨이 모두 갱신되어야 한다
+        Assert.Equal(2, changed.FindAll(p =>
+            p == nameof(ClaudeViewModel.ShortPercentLabel)).Count);
+    }
+
+    [Fact]
+    public void UsageSummaryUnknown_IsNotAZeroPercentClaim()
+    {
+        Assert.False(string.IsNullOrWhiteSpace(Loc.UsageSummaryUnknown));
+        Assert.DoesNotContain("0%", Loc.UsageSummaryUnknown);
+    }
+}

--- a/ClaudeUsageTray/ClaudeUsageTray.csproj
+++ b/ClaudeUsageTray/ClaudeUsageTray.csproj
@@ -7,8 +7,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>1.36.0</Version>
-    <AssemblyVersion>1.36.0</AssemblyVersion>
+    <Version>1.36.1</Version>
+    <AssemblyVersion>1.36.1</AssemblyVersion>
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>false</SelfContained>

--- a/ClaudeUsageTray/Services/CredentialService.cs
+++ b/ClaudeUsageTray/Services/CredentialService.cs
@@ -11,7 +11,7 @@ public class CredentialService : IDisposable
 {
     private static readonly SemaphoreSlim _lock = new(1, 1);
 
-    private static readonly string CredentialsPath = Path.Combine(
+    private static readonly string DefaultCredentialsPath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
         ".claude", ".credentials.json");
 
@@ -19,6 +19,7 @@ public class CredentialService : IDisposable
     private const string ClientId = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
     private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(AppConstants.AuthTimeoutSeconds) };
 
+    private readonly string _credentialsPath;
     private readonly FileSystemWatcher? _watcher;
 
     /// <summary>
@@ -27,12 +28,15 @@ public class CredentialService : IDisposable
     /// </summary>
     public event Action? CredentialsChanged;
 
-    public CredentialService()
+    /// <param name="credentialsPath">자격 파일 경로. null 이면 ~/.claude/.credentials.json (테스트용 주입점).</param>
+    public CredentialService(string? credentialsPath = null)
     {
-        var dir = Path.GetDirectoryName(CredentialsPath)!;
+        _credentialsPath = credentialsPath ?? DefaultCredentialsPath;
+
+        var dir = Path.GetDirectoryName(_credentialsPath)!;
         if (Directory.Exists(dir))
         {
-            _watcher = new FileSystemWatcher(dir, ".credentials.json")
+            _watcher = new FileSystemWatcher(dir, Path.GetFileName(_credentialsPath))
             {
                 NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.FileName,
                 EnableRaisingEvents = true
@@ -64,10 +68,10 @@ public class CredentialService : IDisposable
 
     public ClaudeCredentials? Load()
     {
-        if (!File.Exists(CredentialsPath)) return null;
+        if (!File.Exists(_credentialsPath)) return null;
         try
         {
-            var json = File.ReadAllText(CredentialsPath);
+            var json = File.ReadAllText(_credentialsPath);
             return JsonSerializer.Deserialize<ClaudeCredentials>(json);
         }
         catch (Exception ex)
@@ -83,12 +87,21 @@ public class CredentialService : IDisposable
     public string? GetAccessToken()
     {
         var cred = Load();
-        return cred?.ClaudeAiOauth?.AccessToken;
+        return NullIfBlank(cred?.ClaudeAiOauth?.AccessToken);
     }
+
+    /// <summary>
+    /// Claude Code 가 로그아웃/자격 이관 시 accessToken 을 <b>빈 문자열</b>로 남기고 나머지 필드
+    /// (scopes, subscriptionType 등)만 유지하는 경우가 있다. 빈 값을 그대로 흘려보내면 호출부가
+    /// "토큰 있음"으로 오해해 인증 없는 요청을 보내고, 그 응답(429/401)을 일시적 제한으로
+    /// 오진하게 된다. 여기서 없음(null)으로 정규화한다.
+    /// </summary>
+    private static string? NullIfBlank(string? token) =>
+        string.IsNullOrWhiteSpace(token) ? null : token;
 
     public string? GetOrganizationUuid() => Load()?.OrganizationUuid;
 
-    public bool HasCredentials() => File.Exists(CredentialsPath);
+    public bool HasCredentials() => File.Exists(_credentialsPath);
 
     /// <summary>
     /// Returns the Claude subscription type from stored credentials (e.g. "free", "pro", "max").
@@ -112,11 +125,11 @@ public class CredentialService : IDisposable
             // Token still valid (with 60s buffer)
             if (!oauth.IsExpired &&
                 DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() < oauth.ExpiresAt - 60_000)
-                return oauth.AccessToken;
+                return NullIfBlank(oauth.AccessToken);
 
             // Try to refresh
             var refreshed = await TryRefreshAsync(oauth.RefreshToken);
-            if (refreshed is null) return oauth.AccessToken; // fall back to existing token
+            if (refreshed is null) return NullIfBlank(oauth.AccessToken); // fall back to existing token
 
             // Persist updated credentials
             try
@@ -127,7 +140,7 @@ public class CredentialService : IDisposable
                     oauth.RefreshToken = refreshed.RefreshToken;
 
                 // Merge back — preserve other fields in the JSON
-                var raw = JsonNode.Parse(File.ReadAllText(CredentialsPath))!;
+                var raw = JsonNode.Parse(File.ReadAllText(_credentialsPath))!;
                 raw["claudeAiOauth"]!["accessToken"] = oauth.AccessToken;
                 raw["claudeAiOauth"]!["expiresAt"]   = oauth.ExpiresAt;
                 if (!string.IsNullOrEmpty(refreshed.RefreshToken))
@@ -137,7 +150,7 @@ public class CredentialService : IDisposable
                 _isSelfWriting = true;
                 try
                 {
-                    File.WriteAllText(CredentialsPath,
+                    File.WriteAllText(_credentialsPath,
                         raw.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
                 }
                 finally
@@ -156,7 +169,7 @@ public class CredentialService : IDisposable
                 /* ignore write errors */
             }
 
-            return oauth.AccessToken;
+            return NullIfBlank(oauth.AccessToken);
         }
         finally
         {

--- a/ClaudeUsageTray/Services/LocalizationService.cs
+++ b/ClaudeUsageTray/Services/LocalizationService.cs
@@ -349,6 +349,18 @@ public static class Loc
         _ => $" · resets ~{time} (estimated)"
     };
 
+    /// <summary>할당량을 아직 조회하지 못했을 때 퍼센트 자리에 들어가는 표기.</summary>
+    public static string QuotaUnknownMark => "—";
+
+    /// <summary>할당량 미조회 상태의 요약문 — "0% 사용"으로 단정하지 않기 위한 대체 문구.</summary>
+    public static string UsageSummaryUnknown => Lang switch
+    {
+        "ko" => "사용량을 아직 확인하지 못했습니다",
+        "zh" => "尚未获取使用量",
+        "ja" => "使用量をまだ取得できていません",
+        _ => "Usage not retrieved yet"
+    };
+
     public static string UsageSummary(double usedPercent) => Lang switch
     {
         "ko" => $"{Math.Clamp(usedPercent, 0, 1):P0} 사용 · 잔량 {(1.0 - Math.Clamp(usedPercent, 0, 1)):P0}",
@@ -675,10 +687,10 @@ public static class Loc
     // 막연한 에러 대신 구체적 조치(터미널에서 claude 로그인)를 안내한다.
     public static string NoToken => Lang switch
     {
-        "ko" => "액세스 토큰이 없습니다 — 터미널에서 Claude Code에 로그인(claude → /login)한 뒤 앱을 다시 시작하세요",
-        "zh" => "未找到访问令牌 — 请在终端登录 Claude Code(claude → /login)后重启本应用",
-        "ja" => "アクセストークンがありません — ターミナルで Claude Code にログイン(claude → /login)してからアプリを再起動してください",
-        _ => "No access token — log in to Claude Code in a terminal (claude → /login), then restart the app"
+        "ko" => "액세스 토큰이 없습니다 — 터미널에서 claude auth login 으로 로그인한 뒤 앱을 다시 시작하세요",
+        "zh" => "未找到访问令牌 — 请在终端执行 claude auth login 登录后重启本应用",
+        "ja" => "アクセストークンがありません — ターミナルで claude auth login を実行してログイン後、アプリを再起動してください",
+        _ => "No access token — run `claude auth login` in a terminal, then restart the app"
     };
 
     public static string RateLimited => Lang switch

--- a/ClaudeUsageTray/Services/SessionMonitor.cs
+++ b/ClaudeUsageTray/Services/SessionMonitor.cs
@@ -4,39 +4,33 @@ using ClaudeUsageTray.Models;
 
 namespace ClaudeUsageTray.Services;
 
+/// <summary>
+/// ~/.claude/projects 아래 세션 트랜스크립트(*.jsonl)에서 "오늘" 사용량을 집계한다.
+///
+/// 집계는 항상 <b>오늘 총량</b>이어야 한다 — 호출자(HistoryService.RecordToday)가 결과를
+/// 그날 항목에 덮어쓰기 때문에, 부분 합계를 돌려주면 그대로 히스토리가 오염된다.
+/// 그래서 증분(마지막 읽은 오프셋 이후만 읽기) 방식을 쓰지 않고, 오늘 기록됐을 수 있는
+/// 파일만 골라 매번 전체를 다시 읽는다. 파일 목록 필터가 mtime 기반이라 실제로 여는 파일은
+/// 보통 몇 개뿐이다.
+/// </summary>
 public class SessionMonitor
 {
-    private static readonly string ProjectsPath = Path.Combine(
+    private static readonly string DefaultProjectsPath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
         ".claude", "projects");
 
-    private readonly Dictionary<string, long> _filePositions = new();
-    private FileSystemWatcher? _watcher;
-    private bool _hasChanges;
+    /// <summary>
+    /// mtime 필터의 여유분. 파일시스템 타임스탬프 정밀도·시계 오차로 자정 직후 기록이
+    /// 전날 mtime 을 갖는 경우를 대비한다. 몇 개 더 여는 비용이 누락보다 싸다.
+    /// </summary>
+    private static readonly TimeSpan MTimeTolerance = TimeSpan.FromHours(1);
 
-    public SessionMonitor()
+    private readonly string _projectsPath;
+
+    /// <param name="projectsPath">트랜스크립트 루트. null 이면 ~/.claude/projects (테스트용 주입점).</param>
+    public SessionMonitor(string? projectsPath = null)
     {
-        StartWatcher();
-    }
-
-    private void StartWatcher()
-    {
-        if (!Directory.Exists(ProjectsPath)) return;
-
-        try
-        {
-            _watcher = new FileSystemWatcher(ProjectsPath, "*.jsonl")
-            {
-                IncludeSubdirectories = true,
-                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size
-            };
-            _watcher.Changed += (_, _) => _hasChanges = true;
-            _watcher.EnableRaisingEvents = true;
-        }
-        catch
-        {
-            // Ignore watcher errors
-        }
+        _projectsPath = projectsPath ?? DefaultProjectsPath;
     }
 
     public SessionStats ScanTodayUsage()
@@ -44,30 +38,13 @@ public class SessionMonitor
         var stats = new SessionStats();
         var today = DateTime.Today;
 
-        // Check if any files changed since last scan
-        bool scanAll = !_hasChanges;
-        _hasChanges = false;
+        if (!Directory.Exists(_projectsPath)) return stats;
 
-        if (!Directory.Exists(ProjectsPath)) return stats;
-
-        var jsonlFiles = Directory.GetFiles(ProjectsPath, "*.jsonl", SearchOption.AllDirectories);
-
-        foreach (var file in jsonlFiles)
+        foreach (var file in EnumerateFilesTouchedSince(today))
         {
             try
             {
-                if (scanAll)
-                {
-                    // Full scan: process entire file
-                    ProcessFile(file, today, stats);
-                    _filePositions[file] = new FileInfo(file).Length;
-                }
-                else
-                {
-                    // Incremental scan: only new content
-                    var lastPos = _filePositions.GetValueOrDefault(file, 0);
-                    ProcessFileIncremental(file, today, stats, lastPos);
-                }
+                ProcessFile(file, today, stats);
             }
             catch
             {
@@ -78,71 +55,38 @@ public class SessionMonitor
         return stats;
     }
 
-    private void ProcessFileIncremental(string filePath, DateTime sinceDate, SessionStats stats, long startPosition)
+    /// <summary>
+    /// 오늘 기록이 들어 있을 수 있는 파일만 추린다.
+    /// 마지막 쓰기가 오늘 이전이면 오늘자 항목이 있을 수 없으므로 열지 않는다.
+    /// </summary>
+    private IEnumerable<string> EnumerateFilesTouchedSince(DateTime sinceLocalDate)
     {
+        var cutoffUtc = sinceLocalDate.ToUniversalTime() - MTimeTolerance;
+
+        IEnumerable<string> files;
         try
         {
-            var fileInfo = new FileInfo(filePath);
-            var currentPos = fileInfo.Length;
-
-            if (currentPos <= startPosition)
-            {
-                // File shrunk or unchanged, do full scan
-                ProcessFile(filePath, sinceDate, stats);
-                _filePositions[filePath] = currentPos;
-                return;
-            }
-
-            using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            fs.Seek(startPosition, SeekOrigin.Begin);
-            using var reader = new StreamReader(fs);
-            string? line;
-            bool fileHadActivity = false;
-
-            while ((line = reader.ReadLine()) != null)
-            {
-                if (string.IsNullOrWhiteSpace(line)) continue;
-                try
-                {
-                    using var doc = JsonDocument.Parse(line);
-                    var root = doc.RootElement;
-                    if (!root.TryGetProperty("type", out var typeEl)) continue;
-                    if (typeEl.GetString() != "assistant") continue;
-
-                    DateTime parsedTs = default;
-                    if (root.TryGetProperty("timestamp", out var tsEl) && DateTime.TryParse(tsEl.GetString(), out parsedTs))
-                    {
-                        if (parsedTs.ToLocalTime().Date < sinceDate) continue;
-                        fileHadActivity = true;
-                    }
-
-                    if (!root.TryGetProperty("message", out var msgEl) || 
-                        !msgEl.TryGetProperty("usage", out var usageEl)) continue;
-
-                    stats.TotalInputTokens += usageEl.TryGetProperty("input_tokens", out var inp) ? inp.GetInt64() : 0;
-                    stats.TotalOutputTokens += usageEl.TryGetProperty("output_tokens", out var outp) ? outp.GetInt64() : 0;
-                    stats.TotalCacheReadTokens += usageEl.TryGetProperty("cache_read_input_tokens", out var cr) ? cr.GetInt64() : 0;
-                    stats.TotalCacheWriteTokens += usageEl.TryGetProperty("cache_creation_input_tokens", out var cw) ? cw.GetInt64() : 0;
-
-                    if (parsedTs != default)
-                        stats.HourlyTokens[parsedTs.ToLocalTime().Hour] += 
-                            (usageEl.TryGetProperty("input_tokens", out var inp2) ? inp2.GetInt64() : 0) +
-                            (usageEl.TryGetProperty("output_tokens", out var outp2) ? outp2.GetInt64() : 0);
-
-                    if (root.TryGetProperty("error", out var errEl) && errEl.GetString() == "rate_limit")
-                        stats.HasRateLimitHit = true;
-                }
-                catch { }
-            }
-
-            if (fileHadActivity) stats.SessionCount++;
-            _filePositions[filePath] = currentPos;
+            files = Directory.EnumerateFiles(_projectsPath, "*.jsonl", SearchOption.AllDirectories);
         }
         catch
         {
-            // Fallback to full scan
-            ProcessFile(filePath, sinceDate, stats);
-            try { _filePositions[filePath] = new FileInfo(filePath).Length; } catch { }
+            yield break;
+        }
+
+        foreach (var file in files)
+        {
+            bool touched;
+            try
+            {
+                touched = File.GetLastWriteTimeUtc(file) >= cutoffUtc;
+            }
+            catch
+            {
+                // 상태를 못 읽으면 누락보다 한 번 더 읽는 쪽을 택한다
+                touched = true;
+            }
+
+            if (touched) yield return file;
         }
     }
 

--- a/ClaudeUsageTray/Services/UsageApiService.cs
+++ b/ClaudeUsageTray/Services/UsageApiService.cs
@@ -30,7 +30,9 @@ public class UsageApiService
     public async Task<UsageResponse?> FetchUsageAsync()
     {
         var token = await _credentials.GetValidAccessTokenAsync();
-        if (token is null)
+        // 빈 문자열도 "토큰 없음"이다 — 그대로 보내면 인증 없는 요청이 되어 429 로 돌아오고,
+        // 호출부가 이를 일시적 rate limit 으로 오진한다.
+        if (string.IsNullOrWhiteSpace(token))
         {
             LastError = NoTokenError;
             return null;

--- a/ClaudeUsageTray/ViewModels/ClaudeViewModel.cs
+++ b/ClaudeUsageTray/ViewModels/ClaudeViewModel.cs
@@ -8,10 +8,20 @@ namespace ClaudeUsageTray.ViewModels;
 // UsagePopup.xaml 이 바인딩한다. (자체 새로고침 로직은 MainViewModel 로 일원화되어 제거됨)
 public partial class ClaudeViewModel : ObservableObject
 {
-    [ObservableProperty] private double _shortPercent = 0;
+    [ObservableProperty][NotifyPropertyChangedFor(nameof(ShortPercentLabel))] private double _shortPercent = 0;
     [ObservableProperty] private string _shortReset = "";
-    [ObservableProperty] private double _longPercent = 0;
+    [ObservableProperty][NotifyPropertyChangedFor(nameof(LongPercentLabel))] private double _longPercent = 0;
     [ObservableProperty] private string _longReset = "";
+
+    // 할당량을 한 번이라도 받아왔는지. false 면 ShortPercent/LongPercent 의 0 은 "사용 0%"가 아니라
+    // "아직 모름"이므로, 0% 라고 단정해 보여주지 않는다.
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShortPercentLabel))]
+    [NotifyPropertyChangedFor(nameof(LongPercentLabel))]
+    private bool _hasQuotaData = false;
+
+    public string ShortPercentLabel => HasQuotaData ? ShortPercent.ToString("P0") : Loc.QuotaUnknownMark;
+    public string LongPercentLabel  => HasQuotaData ? LongPercent.ToString("P0")  : Loc.QuotaUnknownMark;
 
     // 시간 진행률(윈도우 경과 비율, 0~1) — 사용량 막대와 비교해 페이스를 육안으로 드러낸다.
     // *UsageCapped = min(사용량, 시간) — 보라 레이어 폭. 사용량이 시간을 앞지른 만큼만 주황으로 노출된다.

--- a/ClaudeUsageTray/ViewModels/MainViewModel.cs
+++ b/ClaudeUsageTray/ViewModels/MainViewModel.cs
@@ -49,9 +49,11 @@ namespace ClaudeUsageTray.ViewModels;
     private string _prevShortDepletion = "";
     private DateTimeOffset? _lastNotifiedEarlyDepletionAt;
 
-    // Last known good API data (kept when rate-limited so UI doesn't reset to 0)
-    private double _lastKnownShortPercent = 0;
-    private double _lastKnownLongPercent = 0;
+    // Last known good API data (kept when rate-limited so UI doesn't reset to 0).
+    // null = 아직 한 번도 조회에 성공하지 못함 — 이 상태를 0% 로 표시하면 "여유 100%"라는
+    // 거짓 정보가 되므로 UI 에서 "—" 로 구분해야 한다.
+    private double? _lastKnownShortPercent;
+    private double? _lastKnownLongPercent;
     private string _lastKnownShortReset = "";
     private string _lastKnownLongReset = "";
 
@@ -1402,7 +1404,10 @@ namespace ClaudeUsageTray.ViewModels;
                 UsageProviderKind.Codex     => Loc.TrayStatusCodex(CodexPercent, CodexDataSource),
                 UsageProviderKind.GeminiCli => Loc.TrayStatusGemini(_lastGeminiRequestCount, _lastGeminiOutputTokens),
                 UsageProviderKind.OpenCode  => Loc.TrayStatusOpenCode(_lastOpenCodeRequestCount, _lastOpenCodeInputTokens, _lastOpenCodeOutputTokens),
-                _ => Loc.TrayStatusClaude(ClaudeVm.ShortPercent)
+                // 미조회 상태에서 "Claude 0%" 라고 쓰면 여유가 100% 라는 뜻으로 읽힌다
+                _ => ClaudeVm.HasQuotaData
+                        ? Loc.TrayStatusClaude(ClaudeVm.ShortPercent)
+                        : $"Claude {Loc.QuotaUnknownMark}"
             };
         }
     }
@@ -1580,6 +1585,7 @@ namespace ClaudeUsageTray.ViewModels;
 
         ClaudeVm.HasError = false;
         ClaudeVm.ErrorMessage = "";
+        ClaudeVm.HasQuotaData = true;
 
         ClaudeVm.ShortPercent = quota.ShortUsagePercent;
         _rawClaudeShortResetAt = quota.ShortResetAt;
@@ -1682,7 +1688,9 @@ namespace ClaudeUsageTray.ViewModels;
                 if (_api.LastRetryAfterSeconds > 0)
                     _apiRetryAfter = DateTimeOffset.UtcNow.AddSeconds(_api.LastRetryAfterSeconds);
             }
-            var sessionStats = _session.ScanTodayUsage();
+            // 트랜스크립트 스캔은 파일 I/O라 수백 ms 이상 걸린다. RefreshAsync 는 UI 스레드에서
+            // 시작될 수 있으므로(계정 전환 직후 등) 반드시 스레드풀로 밀어낸다.
+            var sessionStats = await Task.Run(_session.ScanTodayUsage);
             var syncErrorKind = skipApi ? "api_skipped" : ClassifyClaudeApiError(_api.LastError);
             var syncedClaudeQuota = TrySyncClaudeUsage(
                 currentOrgUuid,
@@ -1733,6 +1741,7 @@ namespace ClaudeUsageTray.ViewModels;
                     ClaudeVm.HasError = false;
                     ClaudeVm.ErrorMessage = "";
                     ClaudeVm.ApiNote = "";
+                    ClaudeVm.HasQuotaData = true;
                     // OAuth-not-allowed 가 해소된 첫 성공 → 첫감지 시각 클리어
                     ClearOAuthNotAllowedFirstSeenIfNeeded();
 
@@ -1871,12 +1880,19 @@ namespace ClaudeUsageTray.ViewModels;
                 }
                 else if (skipApi || _api.LastError != null)
                 {
-                    ClaudeVm.ShortPercent = _lastKnownShortPercent;
+                    // 마지막으로 성공한 값이 있으면 유지하고, 한 번도 없으면 0% 로 단정하지 않는다.
+                    ClaudeVm.HasQuotaData = _lastKnownShortPercent.HasValue || _lastKnownLongPercent.HasValue;
+
+                    ClaudeVm.ShortPercent = _lastKnownShortPercent ?? 0;
                     ClaudeVm.ShortReset   = _lastKnownShortReset;
-                    ClaudeVm.ShortSummary = Loc.UsageSummary(_lastKnownShortPercent);
-                    ClaudeVm.LongPercent  = _lastKnownLongPercent;
+                    ClaudeVm.ShortSummary = _lastKnownShortPercent is { } shortPct
+                        ? Loc.UsageSummary(shortPct)
+                        : Loc.UsageSummaryUnknown;
+                    ClaudeVm.LongPercent  = _lastKnownLongPercent ?? 0;
                     ClaudeVm.LongReset    = _lastKnownLongReset;
-                    ClaudeVm.LongSummary  = Loc.UsageSummary(_lastKnownLongPercent);
+                    ClaudeVm.LongSummary  = _lastKnownLongPercent is { } longPct
+                        ? Loc.UsageSummary(longPct)
+                        : Loc.UsageSummaryUnknown;
 
                     // 403 permission_error: 두 가지 케이스로 세분
                     //   (a) "currently not allowed for this organization" — 신규 계정 검증/조직 OAuth 미활성 (일시적, 24h내 자동 해소 가능성)

--- a/ClaudeUsageTray/Views/UsagePopup.xaml
+++ b/ClaudeUsageTray/Views/UsagePopup.xaml
@@ -486,7 +486,7 @@
                             <ProgressBar Grid.Column="1" Value="{Binding ClaudeVm.ShortPercent}" Maximum="1"
                                          Style="{StaticResource UsageBarStyle}" VerticalAlignment="Center"
                                          Margin="8,0,8,0"/>
-                            <TextBlock Grid.Column="2" Text="{Binding ClaudeVm.ShortPercent, StringFormat={}{0:P0}}"
+                            <TextBlock Grid.Column="2" Text="{Binding ClaudeVm.ShortPercentLabel}"
                                        Foreground="#A78BFA" FontSize="11" FontWeight="SemiBold"
                                        VerticalAlignment="Center"/>
                         </Grid>
@@ -650,7 +650,7 @@
                                     <TextBlock Text="C" Foreground="White" FontSize="8" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                                 </Border>
                                 <TextBlock Grid.Column="1" Text="Claude" Foreground="#F1F5F9" FontSize="11" FontWeight="Bold" VerticalAlignment="Center"/>
-                                <TextBlock Grid.Column="2" Text="{Binding ClaudeVm.ShortPercent, StringFormat={}{0:P0}}" Foreground="#A78BFA" FontSize="13" FontWeight="Bold" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="2" Text="{Binding ClaudeVm.ShortPercentLabel}" Foreground="#A78BFA" FontSize="13" FontWeight="Bold" VerticalAlignment="Center"/>
                             </Grid>
                         </Button>
 
@@ -669,7 +669,7 @@
                                     </Grid.ColumnDefinitions>
                                     <TextBlock Grid.Column="0" Text="{Binding LblFiveHour}" Foreground="#F1F5F9" FontSize="10.5"/>
                                     <StackPanel Grid.Column="1" Orientation="Horizontal">
-                                        <TextBlock Text="{Binding ClaudeVm.ShortPercent, StringFormat={}{0:P0}}" Foreground="#A78BFA" FontSize="11" FontWeight="Bold"/>
+                                        <TextBlock Text="{Binding ClaudeVm.ShortPercentLabel}" Foreground="#A78BFA" FontSize="11" FontWeight="Bold"/>
                                         <TextBlock Text="{Binding ClaudeVm.ShortReset}" Foreground="#8B92B3" FontSize="10" Margin="4,0,0,0"/>
                                     </StackPanel>
                                 </Grid>
@@ -703,7 +703,7 @@
                                     </Grid.ColumnDefinitions>
                                     <TextBlock Grid.Column="0" Text="{Binding LblSevenDay}" Foreground="#F1F5F9" FontSize="10.5"/>
                                     <StackPanel Grid.Column="1" Orientation="Horizontal">
-                                        <TextBlock Text="{Binding ClaudeVm.LongPercent, StringFormat={}{0:P0}}" Foreground="#A78BFA" FontSize="11" FontWeight="Bold"/>
+                                        <TextBlock Text="{Binding ClaudeVm.LongPercentLabel}" Foreground="#A78BFA" FontSize="11" FontWeight="Bold"/>
                                         <TextBlock Text="{Binding ClaudeVm.LongReset}" Foreground="#8B92B3" FontSize="10" Margin="4,0,0,0"/>
                                     </StackPanel>
                                 </Grid>


### PR DESCRIPTION
## 배경

"며칠 전부터 사용량 집계가 제대로 안 된다"는 신고를 실측으로 확인한 결과, 원인이 서로 다른 두 결함이었다.

같은 시각 원본 jsonl 을 직접 합산한 값과 앱이 기록한 값 비교(2026-08-04 16:36):

| | 앱 | 실제 | 비율 |
|---|---|---|---|
| 입력 | 6,602 | 15,241 | 43% |
| 출력 | 1,449,827 | 2,310,435 | 63% |
| 캐시 읽기 | 246,863,767 | 730,166,366 | **34%** |
| 캐시 쓰기 | 5,393,201 | 13,144,130 | 41% |

## 수정 1 — 오늘의 토큰이 "직전 스캔 이후 델타"였다

`ScanTodayUsage()` 는 호출마다 새 `SessionStats` 를 만드는데, 파일 변경이 감지되면 증분 모드로 들어가 활성 세션 파일은 마지막 오프셋 이후만 더했다. 누적하는 곳이 없으니 결과는 그날 총량이 아니라 부분 합계였고, `HistoryService.RecordToday` 가 그 값으로 그날 항목을 **덮어써** 7일 차트와 비용 추정까지 함께 낮아졌다. Claude Code 를 계속 쓰는 동안엔 FileSystemWatcher 가 매번 떠서 영구적으로 증분 모드에 머물렀다 — 작업을 많이 할수록 더 크게 어긋나는 구조.

증분 경로를 걷어내고, mtime 이 오늘 이후인 파일만 골라 매번 전체를 다시 읽는다. 실측 489개 중 실제로 여는 파일은 6개(~0.9초). 증분 경로가 시간대별 집계에서 캐시 토큰을 빼먹어 전체 스캔과 값이 달라지던 불일치도 함께 사라진다.

## 수정 2 — 빈 액세스 토큰을 유효한 토큰으로 취급했다

Claude Code 가 로그아웃하면서 `accessToken`/`refreshToken` 을 빈 문자열로 남기는 경우가 있다(scopes·subscriptionType 등 나머지 필드는 유지). `CredentialService` 는 갱신 실패 후 그 빈 값을 그대로 반환했고, `UsageApiService` 는 `token is null` 만 검사해 통과시켜 인증 없는 요청을 보냈다. Anthropic 이 429(Retry-After 3206)를 돌려주자 앱은 이를 일시적 제한으로 읽고 "API 응답 대기 중 — HH:MM에 자동 재시도"만 반복하며 사용량을 0% 로 고정 표시했다. 실제로는 로그인이 필요한 상태였다.

빈 값을 null 로 정규화하고 호출부도 `IsNullOrWhiteSpace` 로 검사해 로그인 안내로 라우팅한다. `Loc.NoToken` 안내문도 현재 CLI 명령(`claude auth login`)에 맞췄다.

## 수정 3 — 미조회 상태를 "0% 사용 · 잔량 100%"로 단정하던 표시

`_lastKnown*Percent` 를 nullable 로 바꿔 "한 번도 조회에 성공하지 못함"과 "실제 0% 사용"을 구분하고, 전자는 `—` + 안내 문구로 표시한다(트레이 툴팁 포함).

## 부수

트랜스크립트 스캔이 이제 매번 전체 읽기이므로 `Task.Run` 으로 UI 스레드에서 분리했다. (`RefreshAsync` 는 계정 전환 직후 등 UI 스레드에서 시작될 수 있다.)

## 검증

- `dotnet build` 0 warning / 0 error
- `dotnet test -c Release` 181개 통과 (신규 17개)
  - `SessionMonitorTests` — 반복 호출 멱등성, 스캔 사이 파일이 커져도 그날 총량 반환, 전일 제외, 시간대별 집계의 캐시 토큰 포함
  - `CredentialServiceTests` — 빈 문자열/공백 토큰이 null 로 정규화되는지
  - `ClaudeViewModelQuotaLabelTests` — 미조회 `—` vs 실제 0%
- 실데이터 프로브로 새 스캔이 원본 합산과 일치하고 반복 호출에 값이 변하지 않음을 확인 후 프로브 제거

팝업 렌더링 육안 확인은 하지 않았다 — 단일 인스턴스 뮤텍스가 있어 실행 중인 v1.36.0 과 나란히 띄울 수 없다. 바인딩 경로(`ClaudeVm.ShortPercentLabel`/`LongPercentLabel`)는 컴파일된 public 속성명과 일치함을 확인했다.

## 후속

- #98 조직 UUID 를 못 읽어 다중 계정 히스토리 분리가 동작하지 않음 (별도 버그)
- #99 Hardening candidates: v1.36.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
