### PR TITLE
OpenCode Go 실제 사용량 게이지

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 모든 주요 변경 사항을 이 파일에 기록합니다.
 [Keep a Changelog](https://keepachangelog.com/ko/1.0.0/) 형식을 따릅니다.
 
+## [1.38.2] - 2026-08-10
+
+<!-- ko -->
+### 추가
+- **OpenCode Go 실제 사용량 게이지** — 앱 전용 로그인 창에서 OpenCode에 한 번 로그인하면 공식 콘솔이 제공하는 롤링·주간·월간 사용률과 초기화 시각을 트레이 팝업에 표시합니다. Chrome·Edge 프로필이나 기존 브라우저 쿠키는 읽지 않으며 로그인 세션은 앱 전용 WebView2 데이터 폴더에 격리합니다.
+- **안전한 로컬 통계 폴백** — 로그인하지 않았거나 웹 인증·내부 응답 파싱이 실패해도 OpenCode 로컬 DB의 토큰·요청·비용 통계는 그대로 표시합니다. 임의 퍼센트는 다시 만들지 않습니다.
+<!-- /ko -->
+
+<!-- en -->
+### Added
+- **Actual OpenCode Go usage gauges** — After a one-time sign-in in the app-owned login window, the tray popup shows the rolling, weekly, and monthly usage percentages and reset times supplied by the official OpenCode console. The app does not read Chrome or Edge profiles or reuse existing browser cookies; its session stays isolated in an app-owned WebView2 data folder.
+- **Safe local-statistics fallback** — OpenCode token, request, and cost totals from the local database remain available when the user has not signed in or web authentication/internal-response parsing fails. No estimated percentage is reintroduced.
+<!-- /en -->
+
 ## [1.38.1] - 2026-08-10
 
 <!-- ko -->

--- a/ClaudeUsageTray.Tests/Services/OpenCodeWebUsageServiceTests.cs
+++ b/ClaudeUsageTray.Tests/Services/OpenCodeWebUsageServiceTests.cs
@@ -1,0 +1,41 @@
+using ClaudeUsageTray.Services;
+using Xunit;
+
+namespace ClaudeUsageTray.Tests.Services;
+
+public sealed class OpenCodeWebUsageServiceTests
+{
+    [Fact]
+    public void ParseUsage_ReadsOfficialWindowsFromHydrationPayload()
+    {
+        var now = new DateTimeOffset(2026, 8, 10, 12, 0, 0, TimeSpan.FromHours(9));
+        const string html = """
+            <script>self.$R=self.$R||[];
+            $R[28]($R[18],$R[31]={mine:!0,useBalance:!1,
+            rollingUsage:$R[33]={status:"ok",resetInSec:16930,usagePercent:12.5},
+            weeklyUsage:$R[34]={status:"ok",resetInSec:594907,usagePercent:42},
+            monthlyUsage:$R[35]={status:"ok",resetInSec:2676664,usagePercent:87}});
+            </script>
+            """;
+
+        var usage = OpenCodeWebUsageService.ParseUsage(html, now);
+
+        Assert.NotNull(usage);
+        Assert.Equal(0.125, usage.Rolling.UsagePercent, 6);
+        Assert.Equal(0.42, usage.Weekly.UsagePercent, 6);
+        Assert.Equal(0.87, usage.Monthly.UsagePercent, 6);
+        Assert.Equal(now.AddSeconds(16930), usage.Rolling.ResetAt);
+        Assert.Equal(now.AddSeconds(594907), usage.Weekly.ResetAt);
+        Assert.Equal(now.AddSeconds(2676664), usage.Monthly.ResetAt);
+    }
+
+    [Fact]
+    public void ParseUsage_RejectsPartialOrOutOfRangePayloads()
+    {
+        var now = DateTimeOffset.UtcNow;
+        Assert.Null(OpenCodeWebUsageService.ParseUsage(
+            "rollingUsage:$R[1]={resetInSec:1,usagePercent:101}", now));
+        Assert.Null(OpenCodeWebUsageService.ParseUsage(
+            "rollingUsage:$R[1]={resetInSec:1,usagePercent:1}", now));
+    }
+}

--- a/ClaudeUsageTray/App.xaml.cs
+++ b/ClaudeUsageTray/App.xaml.cs
@@ -18,6 +18,7 @@ public partial class App : Application
     private NotifyIcon? _trayIcon;
     private MainViewModel? _vm;
     private UsagePopup? _popup;
+    private OpenCodeWebUsageService? _openCodeWebUsage;
 
     // Menu item references for status updates
     private ToolStripMenuItem? _claudeStatusItem;
@@ -71,6 +72,7 @@ public partial class App : Application
         var codexMonitor = new CodexUsageMonitor();
         var geminiCliMonitor = new GeminiCliUsageMonitor();
         var openCodeMonitor = new OpenCodeUsageMonitor();
+        _openCodeWebUsage = new OpenCodeWebUsageService();
         var antigravityMonitor = new AntigravityUsageMonitor();
         var notifier = new NotificationService(() => _trayIcon);
         var updater = new UpdateService();
@@ -85,7 +87,8 @@ public partial class App : Application
             [nwsProvider, jmaProvider]);
 
         _vm = new MainViewModel(apiService, credService, sessionMonitor, codexMonitor, geminiCliMonitor,
-            openCodeMonitor, antigravityMonitor, notifier, settingsService, updater, history, usageSync, weather, weatherAlert);
+            openCodeMonitor, antigravityMonitor, notifier, settingsService, updater, history, usageSync, weather, weatherAlert,
+            _openCodeWebUsage);
         _popup = new UsagePopup(_vm);
 
         _trayIcon = new NotifyIcon
@@ -401,6 +404,7 @@ public partial class App : Application
 
         _vm?.Dispose();
         _popup?.Dispose();
+        _openCodeWebUsage?.Dispose();
 
         if (_trayIcon != null)
         {

--- a/ClaudeUsageTray/ClaudeUsageTray.csproj
+++ b/ClaudeUsageTray/ClaudeUsageTray.csproj
@@ -7,8 +7,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>1.38.1</Version>
-    <AssemblyVersion>1.38.1</AssemblyVersion>
+    <Version>1.38.2</Version>
+    <AssemblyVersion>1.38.2</AssemblyVersion>
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>false</SelfContained>
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.5" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4078.44" />
     <PackageReference Include="WPF-UI" Version="3.0.5" />
   </ItemGroup>
 

--- a/ClaudeUsageTray/Models/ProviderUsageSnapshot.cs
+++ b/ClaudeUsageTray/Models/ProviderUsageSnapshot.cs
@@ -41,6 +41,20 @@ public class OpenCodeUsageDetails
     public OpenCodePeriodUsage ThisMonth { get; set; } = new();
     public string? LimitKind { get; set; }
     public DateTimeOffset? RetryAt { get; set; }
+    public OpenCodeWebUsage? WebUsage { get; set; }
+}
+
+public sealed class OpenCodeWebUsage
+{
+    public OpenCodeQuotaWindow Rolling { get; init; } = new();
+    public OpenCodeQuotaWindow Weekly { get; init; } = new();
+    public OpenCodeQuotaWindow Monthly { get; init; } = new();
+}
+
+public sealed class OpenCodeQuotaWindow
+{
+    public double UsagePercent { get; init; }
+    public DateTimeOffset ResetAt { get; init; }
 }
 
 public class OpenCodePeriodUsage

--- a/ClaudeUsageTray/Services/LocalizationService.cs
+++ b/ClaudeUsageTray/Services/LocalizationService.cs
@@ -1364,6 +1364,43 @@ public static class Loc
         _ => "Read from the OpenCode local database · may differ from the official console"
     };
 
+    public static string ProviderOpenCodeWebNote => Lang switch
+    {
+        "ko" => "게이지는 OpenCode 공식 콘솔 · 토큰은 로컬 DB 기준",
+        "zh" => "仪表来自 OpenCode 官方控制台 · 令牌来自本地数据库",
+        "ja" => "ゲージは OpenCode 公式コンソール · トークンはローカル DB 基準",
+        _ => "Gauges from the OpenCode console · tokens from the local database"
+    };
+
+    public static string OpenCodeOfficialQuota => Lang switch
+    {
+        "ko" => "OpenCode Go 실제 할당량",
+        "zh" => "OpenCode Go 实际配额",
+        "ja" => "OpenCode Go の実際の割り当て",
+        _ => "OpenCode Go actual quota"
+    };
+
+    public static string OpenCodeRollingUsage => Lang switch { "ko" => "롤링 사용량", "zh" => "滚动用量", "ja" => "ローリング使用量", _ => "Rolling usage" };
+    public static string OpenCodeWeeklyUsage => Lang switch { "ko" => "주간 사용량", "zh" => "每周用量", "ja" => "週間使用量", _ => "Weekly usage" };
+    public static string OpenCodeMonthlyUsage => Lang switch { "ko" => "월간 사용량", "zh" => "每月用量", "ja" => "月間使用量", _ => "Monthly usage" };
+    public static string OpenCodeConnectWeb => Lang switch { "ko" => "OpenCode 로그인", "zh" => "登录 OpenCode", "ja" => "OpenCode にログイン", _ => "Sign in to OpenCode" };
+    public static string OpenCodeConnectingWeb => Lang switch { "ko" => "로그인 확인 중…", "zh" => "正在检查登录…", "ja" => "ログインを確認中…", _ => "Checking sign-in…" };
+    public static string OpenCodeWebLoginTitle => Lang switch { "ko" => "OpenCode 사용량 연결", "zh" => "连接 OpenCode 用量", "ja" => "OpenCode 使用量を接続", _ => "Connect OpenCode usage" };
+    public static string OpenCodeWebLoginCancelled => Lang switch
+    {
+        "ko" => "OpenCode 로그인이 완료되지 않았습니다.",
+        "zh" => "OpenCode 登录未完成。",
+        "ja" => "OpenCode のログインが完了していません。",
+        _ => "OpenCode sign-in was not completed."
+    };
+    public static string OpenCodeResetAt(string value) => Lang switch
+    {
+        "ko" => $"초기화 {value}",
+        "zh" => $"重置 {value}",
+        "ja" => $"リセット {value}",
+        _ => $"Resets {value}"
+    };
+
     public static string OpenCodeFiveHours => Lang switch { "ko" => "최근 5시간", "zh" => "最近 5 小时", "ja" => "直近5時間", _ => "Last 5 hours" };
     public static string OpenCodeSevenDays => Lang switch { "ko" => "최근 7일", "zh" => "最近 7 天", "ja" => "直近7日", _ => "Last 7 days" };
     public static string OpenCodeThisMonth => Lang switch { "ko" => "이번 달", "zh" => "本月", "ja" => "今月", _ => "This month" };

--- a/ClaudeUsageTray/Services/OpenCodeWebUsageService.cs
+++ b/ClaudeUsageTray/Services/OpenCodeWebUsageService.cs
@@ -1,0 +1,234 @@
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Windows;
+using ClaudeUsageTray.Models;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.Wpf;
+
+namespace ClaudeUsageTray.Services;
+
+/// <summary>
+/// Reads the real OpenCode Go quota from an app-private web session. The service never reads
+/// Chrome/Edge profiles or copies browser cookies into application settings.
+/// </summary>
+public sealed class OpenCodeWebUsageService : IDisposable
+{
+    private static readonly Uri WorkspaceUri = new("https://opencode.ai/workspace");
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private Window? _window;
+    private WebView2? _webView;
+    private bool _allowClose;
+    private TaskCompletionSource<OpenCodeWebUsage?>? _pendingNavigation;
+    private OpenCodeWebUsage? _cachedUsage;
+    private DateTimeOffset _cacheExpiresAt;
+    private DateTimeOffset _retryAfter;
+
+    public string? LastError { get; private set; }
+
+    public async Task<OpenCodeWebUsage?> TryGetUsageAsync(bool interactive = false)
+    {
+        var now = DateTimeOffset.Now;
+        if (!interactive && _cachedUsage != null && now < _cacheExpiresAt)
+            return _cachedUsage;
+        if (!interactive && now < _retryAfter)
+            return null;
+
+        await _gate.WaitAsync();
+        try
+        {
+            now = DateTimeOffset.Now;
+            if (!interactive && _cachedUsage != null && now < _cacheExpiresAt)
+                return _cachedUsage;
+
+            LastError = null;
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher == null) return null;
+
+            var usage = await dispatcher.InvokeAsync(() => NavigateAsync(interactive)).Task.Unwrap();
+            if (usage != null)
+            {
+                _cachedUsage = usage;
+                _cacheExpiresAt = DateTimeOffset.Now.AddMinutes(5);
+                _retryAfter = default;
+            }
+            else if (!interactive)
+            {
+                _retryAfter = DateTimeOffset.Now.AddMinutes(30);
+            }
+            return usage;
+        }
+        catch (Exception ex)
+        {
+            LastError = ex.Message;
+            _retryAfter = DateTimeOffset.Now.AddMinutes(30);
+            return null;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task<OpenCodeWebUsage?> NavigateAsync(bool interactive)
+    {
+        await EnsureWebViewAsync(interactive);
+        if (_window == null || _webView?.CoreWebView2 == null) return null;
+
+        if (interactive)
+        {
+            _window.Left = double.NaN;
+            _window.Top = double.NaN;
+            _window.WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            _window.Opacity = 1;
+            _window.ShowInTaskbar = true;
+            _window.Show();
+            _window.Activate();
+        }
+
+        var timeout = interactive ? TimeSpan.FromMinutes(3) : TimeSpan.FromSeconds(20);
+        using var cts = new CancellationTokenSource(timeout);
+        var completion = new TaskCompletionSource<OpenCodeWebUsage?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _pendingNavigation = completion;
+        cts.Token.Register(() => completion.TrySetResult(null));
+
+        async void OnNavigationCompleted(object? sender, CoreWebView2NavigationCompletedEventArgs args)
+        {
+            if (!args.IsSuccess || _webView?.CoreWebView2 == null) return;
+
+            var source = _webView.Source;
+            if (source == null) return;
+            if (source.Host.Equals("auth.opencode.ai", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!interactive) completion.TrySetResult(null);
+                return;
+            }
+            if (!source.Host.Equals("opencode.ai", StringComparison.OrdinalIgnoreCase)) return;
+
+            var workspaceMatch = Regex.Match(source.AbsolutePath, @"^/workspace/(?<id>[^/]+)");
+            if (!workspaceMatch.Success) return;
+            if (!source.AbsolutePath.EndsWith("/go", StringComparison.OrdinalIgnoreCase))
+            {
+                _webView.Source = new Uri($"https://opencode.ai/workspace/{workspaceMatch.Groups["id"].Value}/go");
+                return;
+            }
+
+            try
+            {
+                var encodedHtml = await _webView.CoreWebView2.ExecuteScriptAsync("document.documentElement.outerHTML");
+                var html = JsonSerializer.Deserialize<string>(encodedHtml);
+                completion.TrySetResult(html == null ? null : ParseUsage(html, DateTimeOffset.Now));
+            }
+            catch (Exception ex)
+            {
+                LastError = ex.Message;
+                completion.TrySetResult(null);
+            }
+        }
+
+        _webView.NavigationCompleted += OnNavigationCompleted;
+        _webView.Source = WorkspaceUri;
+        try
+        {
+            return await completion.Task;
+        }
+        finally
+        {
+            _webView.NavigationCompleted -= OnNavigationCompleted;
+            _pendingNavigation = null;
+            if (_window.IsVisible) _window.Hide();
+        }
+    }
+
+    private async Task EnsureWebViewAsync(bool interactive)
+    {
+        if (_webView?.CoreWebView2 != null) return;
+
+        var dataRoot = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "ClaudeUsageTray", "OpenCodeWebSession");
+        Directory.CreateDirectory(dataRoot);
+
+        _webView = new WebView2();
+        _window = new Window
+        {
+            Title = Loc.OpenCodeWebLoginTitle,
+            Width = 920,
+            Height = 720,
+            MinWidth = 640,
+            MinHeight = 520,
+            Content = _webView,
+            ShowInTaskbar = interactive,
+            WindowStartupLocation = WindowStartupLocation.Manual,
+            Left = -32000,
+            Top = -32000,
+            Opacity = 0
+        };
+        _window.Closing += (_, args) =>
+        {
+            if (_allowClose) return;
+            args.Cancel = true;
+            _window.Hide();
+            _pendingNavigation?.TrySetResult(null);
+        };
+
+        // WPF WebView2 needs a presentation source for initialization. The off-screen window is
+        // shown only long enough to create the control, then hidden until the user chooses login.
+        _window.Show();
+        var environment = await CoreWebView2Environment.CreateAsync(userDataFolder: dataRoot);
+        await _webView.EnsureCoreWebView2Async(environment);
+        _webView.CoreWebView2.Settings.AreDevToolsEnabled = false;
+        _webView.CoreWebView2.Settings.IsPasswordAutosaveEnabled = false;
+        _webView.CoreWebView2.Settings.IsGeneralAutofillEnabled = false;
+        if (!interactive) _window.Hide();
+    }
+
+    internal static OpenCodeWebUsage? ParseUsage(string html, DateTimeOffset observedAt)
+    {
+        var rolling = ParseWindow(html, "rollingUsage", observedAt);
+        var weekly = ParseWindow(html, "weeklyUsage", observedAt);
+        var monthly = ParseWindow(html, "monthlyUsage", observedAt);
+        if (rolling == null || weekly == null || monthly == null) return null;
+
+        return new OpenCodeWebUsage { Rolling = rolling, Weekly = weekly, Monthly = monthly };
+    }
+
+    private static OpenCodeQuotaWindow? ParseWindow(string html, string name, DateTimeOffset observedAt)
+    {
+        var block = Regex.Match(html,
+            $@"{Regex.Escape(name)}:\$R\[\d+\]=\{{(?<body>[^}}]+)\}}",
+            RegexOptions.CultureInvariant);
+        if (!block.Success) return null;
+
+        var body = block.Groups["body"].Value;
+        var resetMatch = Regex.Match(body, @"resetInSec:(?<value>\d+)", RegexOptions.CultureInvariant);
+        var percentMatch = Regex.Match(body, @"usagePercent:(?<value>\d+(?:\.\d+)?)", RegexOptions.CultureInvariant);
+        if (!resetMatch.Success || !percentMatch.Success
+            || !double.TryParse(resetMatch.Groups["value"].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var resetSeconds)
+            || !double.TryParse(percentMatch.Groups["value"].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var percent)
+            || resetSeconds < 0 || percent is < 0 or > 100)
+            return null;
+
+        return new OpenCodeQuotaWindow
+        {
+            UsagePercent = percent / 100d,
+            ResetAt = observedAt.AddSeconds(resetSeconds)
+        };
+    }
+
+    public void Dispose()
+    {
+        _gate.Dispose();
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+        dispatcher.Invoke(() =>
+        {
+            _allowClose = true;
+            _webView?.Dispose();
+            _window?.Close();
+            _webView = null;
+            _window = null;
+        });
+    }
+}

--- a/ClaudeUsageTray/ViewModels/MainViewModel.cs
+++ b/ClaudeUsageTray/ViewModels/MainViewModel.cs
@@ -442,7 +442,8 @@ namespace ClaudeUsageTray.ViewModels;
                          NotificationService notifier, SettingsService settingsService,
                          UpdateService updater, HistoryService history,
                          UsageSyncService usageSync,
-                         WeatherService weather, WeatherAlertService weatherAlert)
+                         WeatherService weather, WeatherAlertService weatherAlert,
+                         OpenCodeWebUsageService? openCodeWebUsage = null)
     {
         _api = api;
         _credentials = credentials;
@@ -461,7 +462,7 @@ namespace ClaudeUsageTray.ViewModels;
 
         AntigravityVm = new AntigravityViewModel(antigravity);
         WeatherVm = new WeatherViewModel(weather, weatherAlert);
-        OpenCodeVm = new OpenCodeViewModel(openCode, history);
+        OpenCodeVm = new OpenCodeViewModel(openCode, history, openCodeWebUsage);
         GeminiVm = new GeminiViewModel(geminiCli, history);
         CodexVm = new CodexViewModel(codex, history);
         ClaudeVm = new ClaudeViewModel();
@@ -2282,7 +2283,7 @@ namespace ClaudeUsageTray.ViewModels;
             _lastOpenCodeInputTokens = OpenCodeVm.LastInputTokens;
             _lastOpenCodeOutputTokens = OpenCodeVm.LastOutputTokens;
             _openCodeHasPeriodUsage = OpenCodeVm.HasPeriodUsage;
-            OpenCodeNote = WithSyncNote(Loc.ProviderOpenCodeNote, mergedTotals);
+            OpenCodeNote = WithSyncNote(OpenCodeVm.Note, mergedTotals);
 
             if (HasMergedDeviceTotals(mergedTotals))
             {
@@ -2298,7 +2299,7 @@ namespace ClaudeUsageTray.ViewModels;
                 _lastOpenCodeRequestCount = mergedTotals.RequestCount;
                 _lastOpenCodeInputTokens = mergedTotals.InputTokens;
                 _lastOpenCodeOutputTokens = mergedTotals.OutputTokens;
-                OpenCodePercent = 0;
+                OpenCodePercent = OpenCodeVm.HasWebQuota ? OpenCodeVm.Percent : 0;
             }
 
             UpdateOverallStatus();
@@ -2651,7 +2652,11 @@ namespace ClaudeUsageTray.ViewModels;
     private void OnLanguageChanged()
     {
         // 종료 중이면 Application.Current 가 이미 null 이다 — 갱신할 화면도 없으므로 그냥 넘어간다.
-        System.Windows.Application.Current?.Dispatcher.Invoke(() => OnPropertyChanged(string.Empty));
+        System.Windows.Application.Current?.Dispatcher.Invoke(() =>
+        {
+            OpenCodeVm.RefreshLocalizedLabels();
+            OnPropertyChanged(string.Empty);
+        });
     }
 
     public void Dispose()

--- a/ClaudeUsageTray/ViewModels/OpenCodeViewModel.cs
+++ b/ClaudeUsageTray/ViewModels/OpenCodeViewModel.cs
@@ -8,6 +8,7 @@ public partial class OpenCodeViewModel : ObservableObject
 {
     private readonly OpenCodeUsageMonitor _monitor;
     private readonly HistoryService _history;
+    private readonly OpenCodeWebUsageService? _webUsage;
     private int _lastRequestCount = 0;
     private long _lastInputTokens = 0;
     private long _lastOutputTokens = 0;
@@ -27,6 +28,15 @@ public partial class OpenCodeViewModel : ObservableObject
     [ObservableProperty] private string _monthLabel = "—";
     [ObservableProperty] private string _quotaStatusLabel = "";
     [ObservableProperty] private bool _hasPeriodUsage = false;
+    [ObservableProperty] private bool _hasWebQuota = false;
+    [ObservableProperty] private bool _isWebLoginRunning = false;
+    [ObservableProperty] private string _webLoginError = "";
+    [ObservableProperty] private double _rollingPercent = 0;
+    [ObservableProperty] private double _weeklyPercent = 0;
+    [ObservableProperty] private double _monthlyPercent = 0;
+    [ObservableProperty] private string _rollingResetLabel = "";
+    [ObservableProperty] private string _weeklyResetLabel = "";
+    [ObservableProperty] private string _monthlyResetLabel = "";
     [ObservableProperty] private bool _isActive = false;
     [ObservableProperty] private bool _isUsageEmpty = true;
 
@@ -35,10 +45,18 @@ public partial class OpenCodeViewModel : ObservableObject
     public long LastOutputTokens => _lastOutputTokens;
     public ProviderUsageSnapshot LastSnapshot { get; private set; } = new();
 
-    public OpenCodeViewModel(OpenCodeUsageMonitor monitor, HistoryService history)
+    public bool NeedsWebLogin => !HasWebQuota;
+    public string RollingTitle => Loc.OpenCodeRollingUsage;
+    public string WeeklyTitle => Loc.OpenCodeWeeklyUsage;
+    public string MonthlyTitle => Loc.OpenCodeMonthlyUsage;
+    public string WebLoginLabel => IsWebLoginRunning ? Loc.OpenCodeConnectingWeb : Loc.OpenCodeConnectWeb;
+
+    public OpenCodeViewModel(OpenCodeUsageMonitor monitor, HistoryService history,
+        OpenCodeWebUsageService? webUsage = null)
     {
         _monitor = monitor;
         _history = history;
+        _webUsage = webUsage;
     }
 
     public async Task RefreshAsync()
@@ -46,6 +64,8 @@ public partial class OpenCodeViewModel : ObservableObject
         try
         {
             var snapshot = _monitor.GetTodaySnapshot();
+            var webUsage = _webUsage == null ? null : await _webUsage.TryGetUsageAsync();
+            if (snapshot.OpenCodeDetails != null) snapshot.OpenCodeDetails.WebUsage = webUsage;
             LastSnapshot = snapshot;
             await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
             {
@@ -69,11 +89,12 @@ public partial class OpenCodeViewModel : ObservableObject
                         ? $"오늘 {snapshot.RequestCount}회 · 입력 {UsageCalculator.FormatTokenShort(snapshot.TotalInputTokens)} · 출력 {UsageCalculator.FormatTokenShort(snapshot.TotalOutputTokens)}"
                         : $"Today {snapshot.RequestCount} req · in {UsageCalculator.FormatTokenShort(snapshot.TotalInputTokens)} · out {UsageCalculator.FormatTokenShort(snapshot.TotalOutputTokens)}"
                     : snapshot.ErrorMessage ?? "";
-                Percent = snapshot.ShortUsagePercent;
+                ApplyWebUsage(webUsage);
                 FiveHourLabel = FormatPeriod(snapshot.OpenCodeDetails?.LastFiveHours);
                 SevenDayLabel = FormatPeriod(snapshot.OpenCodeDetails?.LastSevenDays);
                 MonthLabel = FormatPeriod(snapshot.OpenCodeDetails?.ThisMonth);
-                QuotaStatusLabel = FormatQuotaStatus(snapshot.OpenCodeDetails);
+                QuotaStatusLabel = webUsage != null ? Loc.OpenCodeOfficialQuota : FormatQuotaStatus(snapshot.OpenCodeDetails);
+                Note = webUsage != null ? Loc.ProviderOpenCodeWebNote : Loc.ProviderOpenCodeNote;
                 HasPeriodUsage = snapshot.OpenCodeDetails?.ThisMonth.Requests > 0;
                 IsUsageEmpty = !snapshot.HasData;
 
@@ -94,6 +115,73 @@ public partial class OpenCodeViewModel : ObservableObject
         }
     }
 
+    public async Task<bool> ConnectWebUsageAsync()
+    {
+        if (_webUsage == null) return false;
+        IsWebLoginRunning = true;
+        WebLoginError = "";
+        try
+        {
+            var usage = await _webUsage.TryGetUsageAsync(interactive: true);
+            if (usage == null)
+            {
+                WebLoginError = _webUsage.LastError ?? Loc.OpenCodeWebLoginCancelled;
+                return false;
+            }
+
+            await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
+            {
+                ApplyWebUsage(usage);
+                QuotaStatusLabel = Loc.OpenCodeOfficialQuota;
+                Note = Loc.ProviderOpenCodeWebNote;
+                if (LastSnapshot.OpenCodeDetails != null) LastSnapshot.OpenCodeDetails.WebUsage = usage;
+            });
+            return true;
+        }
+        finally
+        {
+            IsWebLoginRunning = false;
+        }
+    }
+
+    private void ApplyWebUsage(OpenCodeWebUsage? usage)
+    {
+        HasWebQuota = usage != null;
+        if (usage == null)
+        {
+            RollingPercent = WeeklyPercent = MonthlyPercent = 0;
+            RollingResetLabel = WeeklyResetLabel = MonthlyResetLabel = "";
+            Percent = 0;
+            return;
+        }
+
+        RollingPercent = usage.Rolling.UsagePercent;
+        WeeklyPercent = usage.Weekly.UsagePercent;
+        MonthlyPercent = usage.Monthly.UsagePercent;
+        RollingResetLabel = Loc.OpenCodeResetAt(UsageCalculator.FormatResetLabel(
+            usage.Rolling.ResetAt, false, true, DateTimeOffset.Now));
+        WeeklyResetLabel = Loc.OpenCodeResetAt(UsageCalculator.FormatResetLabel(
+            usage.Weekly.ResetAt, false, true, DateTimeOffset.Now));
+        MonthlyResetLabel = Loc.OpenCodeResetAt(UsageCalculator.FormatResetLabel(
+            usage.Monthly.ResetAt, false, true, DateTimeOffset.Now));
+        Percent = RollingPercent;
+    }
+
+    partial void OnHasWebQuotaChanged(bool value) => OnPropertyChanged(nameof(NeedsWebLogin));
+    partial void OnIsWebLoginRunningChanged(bool value) => OnPropertyChanged(nameof(WebLoginLabel));
+
+    public void RefreshLocalizedLabels()
+    {
+        OnPropertyChanged(nameof(RollingTitle));
+        OnPropertyChanged(nameof(WeeklyTitle));
+        OnPropertyChanged(nameof(MonthlyTitle));
+        OnPropertyChanged(nameof(WebLoginLabel));
+        var usage = LastSnapshot.OpenCodeDetails?.WebUsage;
+        ApplyWebUsage(usage);
+        QuotaStatusLabel = usage != null ? Loc.OpenCodeOfficialQuota : FormatQuotaStatus(LastSnapshot.OpenCodeDetails);
+        Note = usage != null ? Loc.ProviderOpenCodeWebNote : Loc.ProviderOpenCodeNote;
+    }
+
     private static string FormatPeriod(OpenCodePeriodUsage? period)
     {
         if (period == null || period.Requests == 0) return "—";
@@ -112,6 +200,6 @@ public partial class OpenCodeViewModel : ObservableObject
 
     public void UpdateActiveState(bool isEnabled, bool hideInactive)
     {
-        IsActive = isEnabled && (!hideInactive || _lastRequestCount > 0 || HasPeriodUsage || HasError);
+        IsActive = isEnabled && (!hideInactive || _lastRequestCount > 0 || HasPeriodUsage || HasWebQuota || HasError);
     }
 }

--- a/ClaudeUsageTray/Views/UsagePopup.xaml
+++ b/ClaudeUsageTray/Views/UsagePopup.xaml
@@ -534,12 +534,22 @@
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="OpenCode" Foreground="#FB923C" FontSize="11" FontWeight="SemiBold"
                                        VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                            <ProgressBar Grid.Column="1" Value="{Binding OpenCodeVm.RollingPercent}" Maximum="1"
+                                         Style="{StaticResource OpenCodeBarStyle}" VerticalAlignment="Center"
+                                         Margin="8,0,8,0"
+                                         Visibility="{Binding OpenCodeVm.HasWebQuota, Converter={StaticResource BoolToVisibility}}"/>
                             <TextBlock Grid.Column="1" Text="{Binding OpenCodeVm.QuotaStatusLabel}"
                                        Foreground="#8B92B3" FontSize="9" TextTrimming="CharacterEllipsis"
-                                       VerticalAlignment="Center" Margin="8,0,8,0"/>
+                                       VerticalAlignment="Center" Margin="8,0,8,0"
+                                       Visibility="{Binding OpenCodeVm.NeedsWebLogin, Converter={StaticResource BoolToVisibility}}"/>
+                            <TextBlock Grid.Column="2" Text="{Binding OpenCodeVm.RollingPercent, StringFormat={}{0:P0}}"
+                                       Foreground="#FB923C" FontSize="11" FontWeight="SemiBold"
+                                       VerticalAlignment="Center"
+                                       Visibility="{Binding OpenCodeVm.HasWebQuota, Converter={StaticResource BoolToVisibility}}"/>
                             <TextBlock Grid.Column="2" Text="{Binding OpenCodeOutputLabel}"
                                        Foreground="#FB923C" FontSize="11" FontWeight="SemiBold"
-                                       VerticalAlignment="Center"/>
+                                       VerticalAlignment="Center"
+                                       Visibility="{Binding OpenCodeVm.NeedsWebLogin, Converter={StaticResource BoolToVisibility}}"/>
                         </Grid>
 
                         <Grid Visibility="{Binding AntigravityHasData, Converter={StaticResource BoolToVisibility}}">
@@ -1082,6 +1092,45 @@
 
                         <!-- Detail body — focused 일 때만 -->
                         <StackPanel Margin="10,6,10,0" Visibility="{Binding IsOpenCodeFocused, Converter={StaticResource BoolToVisibility}}">
+                        <!-- OpenCode Go official rolling/weekly/monthly quota -->
+                        <Border Margin="0,0,0,10" Padding="10,9" Background="#1F2433" CornerRadius="8"
+                                Visibility="{Binding OpenCodeVm.HasWebQuota, Converter={StaticResource BoolToVisibility}}">
+                            <StackPanel>
+                                <Grid Margin="0,0,0,3">
+                                    <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
+                                    <TextBlock Text="{Binding OpenCodeVm.RollingTitle}" Foreground="#CBD5E1" FontSize="10" FontWeight="SemiBold"/>
+                                    <TextBlock Grid.Column="1" Text="{Binding OpenCodeVm.RollingPercent, StringFormat={}{0:P0}}" Foreground="#FB923C" FontSize="10" FontWeight="Bold"/>
+                                </Grid>
+                                <ProgressBar Value="{Binding OpenCodeVm.RollingPercent}" Maximum="1" Style="{StaticResource OpenCodeBarStyle}"/>
+                                <TextBlock Text="{Binding OpenCodeVm.RollingResetLabel}" Foreground="#69708D" FontSize="9" Margin="0,3,0,7"/>
+
+                                <Grid Margin="0,0,0,3">
+                                    <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
+                                    <TextBlock Text="{Binding OpenCodeVm.WeeklyTitle}" Foreground="#CBD5E1" FontSize="10" FontWeight="SemiBold"/>
+                                    <TextBlock Grid.Column="1" Text="{Binding OpenCodeVm.WeeklyPercent, StringFormat={}{0:P0}}" Foreground="#FB923C" FontSize="10" FontWeight="Bold"/>
+                                </Grid>
+                                <ProgressBar Value="{Binding OpenCodeVm.WeeklyPercent}" Maximum="1" Style="{StaticResource OpenCodeBarStyle}"/>
+                                <TextBlock Text="{Binding OpenCodeVm.WeeklyResetLabel}" Foreground="#69708D" FontSize="9" Margin="0,3,0,7"/>
+
+                                <Grid Margin="0,0,0,3">
+                                    <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
+                                    <TextBlock Text="{Binding OpenCodeVm.MonthlyTitle}" Foreground="#CBD5E1" FontSize="10" FontWeight="SemiBold"/>
+                                    <TextBlock Grid.Column="1" Text="{Binding OpenCodeVm.MonthlyPercent, StringFormat={}{0:P0}}" Foreground="#FB923C" FontSize="10" FontWeight="Bold"/>
+                                </Grid>
+                                <ProgressBar Value="{Binding OpenCodeVm.MonthlyPercent}" Maximum="1" Style="{StaticResource OpenCodeBarStyle}"/>
+                                <TextBlock Text="{Binding OpenCodeVm.MonthlyResetLabel}" Foreground="#69708D" FontSize="9" Margin="0,3,0,0"/>
+                            </StackPanel>
+                        </Border>
+
+                        <StackPanel Margin="0,0,0,10" Visibility="{Binding OpenCodeVm.NeedsWebLogin, Converter={StaticResource BoolToVisibility}}">
+                            <Button Click="OpenCodeWebLogin_Click" HorizontalAlignment="Left" Padding="10,5"
+                                    Background="#9A3412" Foreground="#FFEDD5" BorderBrush="#C2410C" BorderThickness="1"
+                                    Content="{Binding OpenCodeVm.WebLoginLabel}"/>
+                            <TextBlock Text="{Binding OpenCodeVm.WebLoginError}" Foreground="#EF4444" FontSize="9"
+                                       TextWrapping="Wrap" Margin="0,4,0,0"
+                                       Visibility="{Binding OpenCodeVm.WebLoginError, Converter={StaticResource StringToVisibility}}"/>
+                        </StackPanel>
+
                         <!-- Usage Empty Placeholder (OpenCode) -->
                         <TextBlock Text="{Binding LblOpenCodeNoUsage}" Foreground="#5A5F7A" FontSize="10" FontStyle="Italic" Margin="0,0,0,10"
                                    Visibility="{Binding IsOpenCodeUsageEmpty, Converter={StaticResource BoolToVisibility}}"/>

--- a/ClaudeUsageTray/Views/UsagePopup.xaml.cs
+++ b/ClaudeUsageTray/Views/UsagePopup.xaml.cs
@@ -450,6 +450,12 @@ public partial class UsagePopup : Window, IDisposable
     private void CodexFocus_Click(object sender, RoutedEventArgs e)    => SetFocusedProvider(Models.UsageProviderKind.Codex);
     private void GeminiFocus_Click(object sender, RoutedEventArgs e)   => SetFocusedProvider(Models.UsageProviderKind.GeminiCli);
     private void OpenCodeFocus_Click(object sender, RoutedEventArgs e) => SetFocusedProvider(Models.UsageProviderKind.OpenCode);
+    private async void OpenCodeWebLogin_Click(object sender, RoutedEventArgs e)
+    {
+        if (_vm.OpenCodeVm.IsWebLoginRunning) return;
+        if (await _vm.OpenCodeVm.ConnectWebUsageAsync())
+            await _vm.RefreshAsync();
+    }
     private void AntigravityFocus_Click(object sender, RoutedEventArgs e) => SetFocusedProvider(Models.UsageProviderKind.Antigravity);
 
     private void SetFocusedProvider(string provider)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Windows 시스템 트레이에서 Claude, Codex(ChatGPT), Gemini CLI, OpenCode A
 - **변경 이력**: [CHANGELOG.md](CHANGELOG.md)
 
 ## 이슈
+- `기능` OpenCode Go 실제 사용량 게이지 연동 (2026-08-10): 웹 대시보드가 제공하는 롤링·주간·월간 실제 사용률과 초기화 시간을 안전한 로컬 인증 경로로 조회해 Claude와 같은 게이지로 표시한다. 웹 세션 쿠키나 브라우저 프로필을 직접 읽지 않으며, 인증 실패·내부 API 변경·비구독 계정에서는 기존 로컬 DB 통계를 유지한다. #117
 - `개선` OpenCode 실제 사용량·할당량 구분 표시 (2026-08-10): 기존 OpenCode 게이지가 오늘 출력 토큰을 최근 7일 최대치와 비교한 값을 실제 구독 할당량처럼 표시해 오해를 만들었다. 로컬 DB에서 확인 가능한 최근 5시간·7일·월간 토큰/요청/비용은 실제 누적으로 표시하고, 서버가 총량을 공개하지 않는 무료·Zen 사용량은 임의 퍼센트를 만들지 않는다. 무료 또는 Go 한도 오류에 재시도 시각이 포함되면 소진 상태와 초기화 시각을 표시한다. #114
 - `버그` 오늘 요청이 없는 PC 에서 Codex 시간선이 오른쪽 끝에 박힘 (2026-08-07): 로그 스캔이 토큰만 오늘로 거르고 `rate_limits` 는 날짜와 무관하게 최신 줄에서 가져와, 며칠 전의 이미 끝난 창이 그대로 표시됐다. `TimeProgress` 가 지난 리셋을 1 로 clamp 하므로 마커가 오른쪽 끝에 고정되고, 같은 화면에서 `FormatResetLabel` 은 빈 문자열이라 앞뒤가 맞지 않았다(`resets_at: 0` → 1970, 날짜를 안 보는 추정 리셋도 같은 결과). 창 밖이면 위치를 지어내지 않고 마커를 숨기며 끝난 창의 사용률도 버리도록 수정. #111
 - `기능` 에이전트 전체 다중 PC 동기화 (2026-08-07): #78 의 동기화가 Claude 할당량만 되읽고, Codex·Gemini CLI·OpenCode 는 스냅샷을 쓰기만 하고 아무도 읽지 않았으며 Antigravity 는 동기화가 없었다. 계정 단위로 내려오는 할당량(Codex·Antigravity)은 로컬에 없을 때 다른 PC 값으로 채우고, 시간선 역산에 필요한 `window_minutes` 도 함께 옮긴다. 기기 기준으로 계산되는 percent(Gemini CLI·OpenCode)는 공유하지 않고 합산 토큰으로 다시 계산한다. #111
@@ -90,7 +91,7 @@ Windows 시스템 트레이에서 Claude, Codex(ChatGPT), Gemini CLI, OpenCode A
 - **Claude (API)**: 실시간 5시간 / 7일 윈도우 할당량 및 소진 예측
 - **Codex (ChatGPT Plan)**: ChatGPT 플랜 사용량 상태 확인
 - **Gemini CLI**: 로컬 로그 기반 요청 수 및 출력 토큰 실시간 추적
-- **OpenCode**: 로컬 DB 기반 오늘의 입력/출력 토큰 모니터링
+- **OpenCode**: 공식 Go 롤링/주간/월간 사용량 게이지 + 로컬 DB 기반 토큰 모니터링
 - **날씨 알림**: 설정한 위치의 현재 날씨, 예보, 특보를 트레이 툴팁과 알림 경로로 확인
 - **통합 트레이 툴팁**: 아이콘에 마우스를 올리면 4개 공급자의 상태 요약 즉시 확인
 - **동적 트레이 아이콘**: Claude 5시간 사용량 기준 게이지 표시
@@ -130,6 +131,7 @@ Windows 시스템 트레이에서 Claude, Codex(ChatGPT), Gemini CLI, OpenCode A
 
 ### 4. OpenCode
 - **DB 분석**: OpenCode가 로컬에 저장하는 SQLite DB에서 오늘 사용된 메시지의 입력/출력/캐시 토큰을 집계합니다.
+- **Go 할당량**: 앱 전용 로그인 창으로 연결하면 공식 콘솔의 롤링/주간/월간 사용률과 초기화 시각을 표시합니다. 기존 브라우저 로그인 정보는 읽지 않습니다.
 
 ### 5. Antigravity (Google Gemini Code Assist IDE) — v1.31.0+
 - **인증**: Windows Credential Manager 의 `gemini:antigravity` 항목(Antigravity 가 로그인 후 자동 저장하는 OAuth refresh token)을 재사용.


### PR DESCRIPTION
## 변경 내용
- 앱 전용 WebView2 로그인 세션으로 OpenCode Go 공식 롤링·주간·월간 사용률과 초기화 시각을 조회
- Claude 계열과 같은 오렌지 게이지를 컴팩트/상세 화면에 표시
- Chrome·Edge 프로필과 기존 브라우저 쿠키를 읽지 않고 앱 데이터 폴더에 세션 격리
- 웹 인증 또는 내부 응답 파싱 실패 시 기존 로컬 DB 토큰·요청·비용 통계 유지
- 4개 언어, hydration 응답 파서 회귀 테스트, v1.38.2 변경 이력 추가

## 이유
OpenCode Go 공식 콘솔에는 실제 할당량이 있지만 기존 앱은 공개 API가 없다는 전제에서 로컬 누적값만 표시했습니다. 로그인된 웹 응답에 실제 사용률이 존재함을 확인해, 임의 퍼센트 없이 공식 값을 표시합니다.

## 검증
- `dotnet test claude-usage-tray-windows.sln -c Release` — 286개 통과
- `dotnet build claude-usage-tray-windows.sln -c Release` — 경고 0, 오류 0
- CI와 같은 framework-dependent 단일 파일 publish 성공
- 새 실행 파일 25초 실행 및 WebView2 초기화 후 크래시 없음

Closes #117