### PR TITLE
Antigravity 게이지를 사전 설정 없이 앱 화면과 같게 표시

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 모든 주요 변경 사항을 이 파일에 기록합니다.
 [Keep a Changelog](https://keepachangelog.com/ko/1.0.0/) 형식을 따릅니다.
 
+## [1.39.0] - 2026-08-11
+
+<!-- ko -->
+### 수정
+- **Antigravity 게이지가 사전 설정 없이는 뜨지 않던 문제** — 사용량을 조회하기도 전에 사용자가 직접 만들어야 하는 OAuth client 파일을 요구해, 그 파일이 없는 대부분의 PC 에서 섹션이 조용히 사라졌습니다. 파일을 만들려면 실행 중인 `language_server.exe` 의 400MB 메모리 덤프를 떠서 값을 뽑아내야 했습니다. 그런데 Windows 자격 증명 관리자에는 refresh token 뿐 아니라 **아직 유효한 access token 이 함께** 저장돼 있어서, 이 과정 자체가 필요 없었습니다. 이제 저장된 토큰을 먼저 쓰고, 만료됐을 때만 설치된 `language_server.exe` 에서 client 값을 자동으로 찾아 갱신합니다. Antigravity 에 로그인만 되어 있으면 **설정할 것이 없습니다.**
+
+### 변경
+- **Antigravity 사용량이 앱 화면과 같은 게이지로 표시됩니다** — 기존에는 `retrieveUserQuota` 가 주는 모델별 요청 잔량을 보여줘서, Antigravity 의 `Models & Usage` 화면에 있는 게이지와 서로 다른 값이었습니다. 이제 같은 출처(`retrieveUserQuotaSummary`)를 사용해 `Gemini Models` 와 `Claude and GPT models` 각각의 **주간·5시간 잔여량** 네 칸을 그대로 보여줍니다.
+- **아직 쓰지 않은 창도 표시합니다** — 사용률이 0% 인 항목을 목록에서 빼고 있어서, 그 주에 아무것도 쓰지 않았으면 상세를 펼쳐도 빈 화면이었습니다. Antigravity 앱은 이 경우에도 100% 게이지를 보여줍니다.
+- **트레이 게이지는 가장 많이 쓴 창을 기준으로 합니다** — 창마다 한도가 따로 걸리므로 평균을 쓰면 급한 제약이 가려집니다(주간 90% + 5시간 0% → 45%로 표시되던 문제).
+- Antigravity 를 실행하지 않아도 조회됩니다. 앱의 로컬 서버가 아니라 Google 백엔드를 직접 호출합니다.
+<!-- /ko -->
+
+<!-- en -->
+### Fixed
+- **The Antigravity gauge never appeared without manual setup** — Before reading any usage, the app demanded an OAuth client file that users had to create themselves, so on most PCs the section simply vanished. Producing that file meant taking a 400MB memory dump of the running `language_server.exe` and extracting the values by hand. Yet the Windows Credential Manager already stores **a still-valid access token** alongside the refresh token, which made the whole procedure unnecessary. The stored token is now used first, and the client values are located automatically from the installed `language_server.exe` only when the token has expired. If you are signed in to Antigravity, **there is nothing to configure.**
+
+### Changed
+- **Antigravity usage now shows the same gauge as the app itself** — The old call (`retrieveUserQuota`) returned per-model request allowances, which did not match the gauge on Antigravity's `Models & Usage` screen. The app now reads the same source (`retrieveUserQuotaSummary`) and shows the four windows verbatim: weekly and five-hour remaining for `Gemini Models` and for `Claude and GPT models`.
+- **Windows you have not used yet are kept on screen** — Rows at 0% usage were filtered out, so during a week with no activity the expanded view was blank. Antigravity itself shows a full gauge in that situation.
+- **The tray gauge follows the most consumed window** — Each window carries its own limit, so averaging hides the binding constraint (90% weekly + 0% five-hour used to read as 45%).
+- Usage is read even when Antigravity is not running, since the request goes to Google's backend rather than the app's local server.
+<!-- /en -->
+
 ## [1.38.11] - 2026-08-11
 
 <!-- ko -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Antigravity 사용량이 앱 화면과 같은 게이지로 표시됩니다** — 기존에는 `retrieveUserQuota` 가 주는 모델별 요청 잔량을 보여줘서, Antigravity 의 `Models & Usage` 화면에 있는 게이지와 서로 다른 값이었습니다. 이제 같은 출처(`retrieveUserQuotaSummary`)를 사용해 `Gemini Models` 와 `Claude and GPT models` 각각의 **주간·5시간 잔여량** 네 칸을 그대로 보여줍니다.
 - **아직 쓰지 않은 창도 표시합니다** — 사용률이 0% 인 항목을 목록에서 빼고 있어서, 그 주에 아무것도 쓰지 않았으면 상세를 펼쳐도 빈 화면이었습니다. Antigravity 앱은 이 경우에도 100% 게이지를 보여줍니다.
 - **트레이 게이지는 가장 많이 쓴 창을 기준으로 합니다** — 창마다 한도가 따로 걸리므로 평균을 쓰면 급한 제약이 가려집니다(주간 90% + 5시간 0% → 45%로 표시되던 문제).
+- **게이지 이름이 앱 언어로 표시됩니다** — 서버는 이름을 영어로만 내려주므로 `Gemini 모델 · 주간 잔여량` 처럼 네 가지 언어로 옮겨 보여줍니다. 아직 모르는 항목이 오면 서버가 준 문구를 그대로 씁니다.
 - Antigravity 를 실행하지 않아도 조회됩니다. 앱의 로컬 서버가 아니라 Google 백엔드를 직접 호출합니다.
 <!-- /ko -->
 
@@ -24,6 +25,7 @@
 - **Antigravity usage now shows the same gauge as the app itself** — The old call (`retrieveUserQuota`) returned per-model request allowances, which did not match the gauge on Antigravity's `Models & Usage` screen. The app now reads the same source (`retrieveUserQuotaSummary`) and shows the four windows verbatim: weekly and five-hour remaining for `Gemini Models` and for `Claude and GPT models`.
 - **Windows you have not used yet are kept on screen** — Rows at 0% usage were filtered out, so during a week with no activity the expanded view was blank. Antigravity itself shows a full gauge in that situation.
 - **The tray gauge follows the most consumed window** — Each window carries its own limit, so averaging hides the binding constraint (90% weekly + 0% five-hour used to read as 45%).
+- **Gauge labels follow the app language** — The server sends these names in English only, so they are now translated into all four languages (for example `Gemini 모델 · 주간 잔여량`). Unrecognized entries keep the server's own wording.
 - Usage is read even when Antigravity is not running, since the request goes to Google's backend rather than the app's local server.
 <!-- /en -->
 

--- a/ClaudeUsageTray.Tests/Services/AntigravityOAuthClientLocatorTests.cs
+++ b/ClaudeUsageTray.Tests/Services/AntigravityOAuthClientLocatorTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using ClaudeUsageTray.Services;
+using Xunit;
+
+namespace ClaudeUsageTray.Tests.Services;
+
+/// <summary>
+/// 바이너리에서 OAuth client 자격 증명을 뽑아내는 스캐너.
+/// 실제 바이너리에서는 이 값들이 인접한 다른 문자열과 경계 없이 붙어 있어서, 문자 종류만으로 자르면
+/// 옆 문자열을 함께 먹는다. 그 상황을 픽스처로 재현해 둔다.
+/// </summary>
+public sealed class AntigravityOAuthClientLocatorTests
+{
+    // 형식만 같은 가짜 값이다. 실제 자격 증명을 픽스처에 두면 저장소에 secret 이 남고,
+    // Google 의 secret-scanning 정책상 폐기될 수 있다. 조각을 이어 붙이는 것도 같은 이유다.
+    private const string IdSuffix = ".apps.googleusercontent.com";
+    private static readonly string ClientId = "123456789012-" + new string('a', 30) + IdSuffix;
+    private static readonly string ClientSecret = "GOCSPX-" + new string('b', 28);   // 접두사 + 28자
+
+    private static Stream StreamOf(string text) => new MemoryStream(Encoding.ASCII.GetBytes(text));
+
+    [Fact]
+    public void ScanCandidates_FindsPair_WhenValuesAreGluedToNeighbouringStrings()
+    {
+        // "it" + client_id, secret + "cached" 처럼 앞뒤에 다른 문자열이 붙은 실제 배치.
+        using var stream = StreamOf($"runtimeit{ClientId}\0somethingelse{ClientSecret}cachedtail");
+
+        var pairs = AntigravityOAuthClientLocator.ScanCandidates(stream);
+
+        var pair = Assert.Single(pairs);
+        Assert.Equal(ClientId, pair.ClientId);
+        Assert.Equal(ClientSecret, pair.ClientSecret);
+    }
+
+    [Fact]
+    public void ScanCandidates_ReturnsEveryCombination_WhenBinaryHoldsSeveralOfEach()
+    {
+        string otherId = "987654321098-" + new string('c', 30) + IdSuffix;
+        string otherSecret = "GOCSPX-" + new string('d', 28);
+
+        using var stream = StreamOf($"{ClientId} {otherId} {ClientSecret} {otherSecret}");
+
+        var pairs = AntigravityOAuthClientLocator.ScanCandidates(stream);
+
+        // 바이너리에 짝 정보가 없으므로 조합을 모두 내놓고 호출부가 차례로 시도한다.
+        Assert.Equal(4, pairs.Count);
+        Assert.Contains(pairs, p => p.ClientId == ClientId && p.ClientSecret == ClientSecret);
+        Assert.Contains(pairs, p => p.ClientId == otherId && p.ClientSecret == otherSecret);
+    }
+
+    [Fact]
+    public void ScanCandidates_Deduplicates_WhenSameValueAppearsRepeatedly()
+    {
+        using var stream = StreamOf(string.Concat(Enumerable.Repeat($"{ClientId}|{ClientSecret}|", 5)));
+
+        Assert.Single(AntigravityOAuthClientLocator.ScanCandidates(stream));
+    }
+
+    [Theory]
+    // 숫자 프로젝트 번호가 너무 짧다
+    [InlineData("123-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.apps.googleusercontent.com")]
+    // 하이픈이 없다
+    [InlineData("123456789012aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.apps.googleusercontent.com")]
+    // 프로젝트 해시가 너무 짧다
+    [InlineData("123456789012-abc.apps.googleusercontent.com")]
+    public void ScanCandidates_IgnoresIds_ThatDoNotMatchGoogleFormat(string malformedId)
+    {
+        using var stream = StreamOf($"{malformedId} {ClientSecret}");
+
+        Assert.Empty(AntigravityOAuthClientLocator.ScanCandidates(stream));
+    }
+
+    [Fact]
+    public void ScanCandidates_IgnoresSecret_WhenBodyIsShorterThanGoogleFormat()
+    {
+        using var stream = StreamOf($"{ClientId} GOCSPX-tooshort!!");
+
+        Assert.Empty(AntigravityOAuthClientLocator.ScanCandidates(stream));
+    }
+
+    [Fact]
+    public void ScanCandidates_TakesFixedLengthBody_WhenSecretRunsIntoAdjacentText()
+    {
+        // secret 뒤에 문자가 계속 이어져도 접두사 뒤 28자에서 끊어야 한다.
+        using var stream = StreamOf($"{ClientId} {ClientSecret}TrailingGarbageAAAA");
+
+        var pair = Assert.Single(AntigravityOAuthClientLocator.ScanCandidates(stream));
+        Assert.Equal(ClientSecret, pair.ClientSecret);
+        Assert.Equal(35, pair.ClientSecret.Length);
+    }
+
+    [Fact]
+    public void ScanCandidates_FindsValues_WhenTheyStraddleTheReadChunkBoundary()
+    {
+        // 청크는 4MB 단위로 읽는다. 경계에 걸친 문자열을 놓치면 실제 바이너리에서 간헐적으로 실패한다.
+        const int chunkSize = 4 * 1024 * 1024;
+        var padding = new string('x', chunkSize - 20);
+
+        using var stream = StreamOf($"{padding}{ClientId} {ClientSecret} tail");
+
+        var pair = Assert.Single(AntigravityOAuthClientLocator.ScanCandidates(stream));
+        Assert.Equal(ClientId, pair.ClientId);
+        Assert.Equal(ClientSecret, pair.ClientSecret);
+    }
+
+    [Fact]
+    public void ScanCandidates_ReturnsEmpty_WhenNeitherValueIsPresent()
+    {
+        using var stream = StreamOf("no credentials in this binary at all");
+
+        Assert.Empty(AntigravityOAuthClientLocator.ScanCandidates(stream));
+    }
+}

--- a/ClaudeUsageTray.Tests/Services/AntigravityUsageMonitorTests.cs
+++ b/ClaudeUsageTray.Tests/Services/AntigravityUsageMonitorTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using ClaudeUsageTray.Services;
+using Xunit;
+
+namespace ClaudeUsageTray.Tests.Services;
+
+/// <summary>
+/// 응답·자격 증명 파싱만 검증한다. HTTP 자체는 비공식 API 라 테스트로 고정하지 않는다.
+/// 픽스처는 실제 retrieveUserQuotaSummary 응답에서 가져왔다.
+/// </summary>
+public sealed class AntigravityUsageMonitorTests
+{
+    private const string RealSummaryResponse = """
+    {
+      "groups": [
+        {
+          "buckets": [
+            { "bucketId": "gemini-weekly", "displayName": "Weekly Limit Remaining", "window": "weekly",
+              "resetTime": "2026-08-18T08:04:36Z", "remainingFraction": 1 },
+            { "bucketId": "gemini-5h", "displayName": "Five Hour Limit Remaining", "window": "5h",
+              "resetTime": "2026-08-11T13:04:36Z", "remainingFraction": 0.42 }
+          ],
+          "displayName": "Gemini Models",
+          "description": "Models within this group: Gemini Flash, Gemini Pro"
+        },
+        {
+          "buckets": [
+            { "bucketId": "3p-weekly", "displayName": "Weekly Limit Remaining", "window": "weekly",
+              "resetTime": "2026-08-18T08:04:36Z", "remainingFraction": 0.9 },
+            { "bucketId": "3p-5h", "displayName": "Five Hour Limit Remaining", "window": "5h",
+              "resetTime": "2026-08-11T13:04:36Z", "remainingFraction": 1 }
+          ],
+          "displayName": "Claude and GPT models",
+          "description": "Models within this group: Claude Opus, Claude Sonnet, GPT-OSS"
+        }
+      ],
+      "description": "Within each group, models share a weekly limit and a 5-hour limit."
+    }
+    """;
+
+    [Fact]
+    public void ParseSummary_FlattensGroupsIntoBuckets_WithComposedDisplayNames()
+    {
+        using var doc = JsonDocument.Parse(RealSummaryResponse);
+
+        var buckets = AntigravityUsageMonitor.ParseSummary(doc);
+
+        Assert.Equal(4, buckets.Count);
+        Assert.Equal(
+            ["gemini-weekly", "gemini-5h", "3p-weekly", "3p-5h"],
+            buckets.Select(b => b.ModelId));
+        Assert.Equal("Gemini Models · Weekly Limit Remaining", buckets[0].DisplayName);
+        Assert.Equal("Claude and GPT models · Five Hour Limit Remaining", buckets[3].DisplayName);
+        Assert.Equal(["weekly", "5h", "weekly", "5h"], buckets.Select(b => b.TokenType));
+        Assert.Equal(0.42, buckets[1].RemainingFraction, 3);
+        Assert.Equal(
+            new DateTimeOffset(2026, 8, 18, 8, 4, 36, TimeSpan.Zero),
+            buckets[0].ResetTime);
+    }
+
+    [Fact]
+    public void ParseSummary_UnwrapsResponseEnvelope_WhenServedByLocalLanguageServer()
+    {
+        // 로컬 language server 를 거치면 같은 본문이 "response" 아래로 한 겹 들어간다.
+        using var doc = JsonDocument.Parse($$"""{"response": {{RealSummaryResponse}} }""");
+
+        var buckets = AntigravityUsageMonitor.ParseSummary(doc);
+
+        Assert.Equal(4, buckets.Count);
+        Assert.Equal("Gemini Models · Weekly Limit Remaining", buckets[0].DisplayName);
+    }
+
+    [Theory]
+    [InlineData("""{"groups": []}""")]
+    [InlineData("""{"groups": [{"displayName": "Gemini Models"}]}""")]   // buckets 누락
+    [InlineData("""{"description": "no groups at all"}""")]
+    [InlineData("""{"groups": "not-an-array"}""")]
+    public void ParseSummary_ReturnsEmpty_WhenShapeIsUnexpected(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+
+        Assert.Empty(AntigravityUsageMonitor.ParseSummary(doc));
+    }
+
+    [Fact]
+    public void ParseSummary_ClampsFractionAndToleratesMissingFields()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+          "groups": [{
+            "displayName": "Gemini Models",
+            "buckets": [
+              { "bucketId": "over",    "remainingFraction": 1.4 },
+              { "bucketId": "under",   "remainingFraction": -0.2 },
+              { "bucketId": "missing" },
+              { "bucketId": "badreset", "remainingFraction": 0.5, "resetTime": "not-a-date" }
+            ]
+          }]
+        }
+        """);
+
+        var buckets = AntigravityUsageMonitor.ParseSummary(doc);
+
+        Assert.Equal(1.0, buckets[0].RemainingFraction);
+        Assert.Equal(0.0, buckets[1].RemainingFraction);
+        Assert.Equal(1.0, buckets[2].RemainingFraction);   // 값이 없으면 "다 남았다" 로 둔다
+        Assert.Null(buckets[2].ResetTime);
+        Assert.Null(buckets[3].ResetTime);                 // 파싱 실패한 시각은 지어내지 않는다
+        Assert.Equal("Gemini Models", buckets[2].DisplayName);  // 버킷 이름이 없으면 그룹 이름만
+    }
+
+    [Theory]
+    [InlineData("Gemini Models", "Weekly Limit", "Gemini Models · Weekly Limit")]
+    [InlineData("", "Weekly Limit", "Weekly Limit")]
+    [InlineData("Gemini Models", "", "Gemini Models")]
+    [InlineData("", "", "")]
+    [InlineData("  Gemini Models  ", "  Weekly Limit  ", "Gemini Models · Weekly Limit")]
+    public void ComposeDisplayName_JoinsAvailableParts(string group, string bucket, string expected)
+    {
+        Assert.Equal(expected, AntigravityUsageMonitor.ComposeDisplayName(group, bucket));
+    }
+
+    [Fact]
+    public void ParseCredentialBlob_ReadsTokensAndExpiry()
+    {
+        var cred = AntigravityUsageMonitor.ParseCredentialBlob("""
+        {
+          "token": {
+            "access_token": "ya29.sample",
+            "token_type": "Bearer",
+            "refresh_token": "1//sample",
+            "expiry": "2026-08-11T17:36:25Z"
+          },
+          "id_token": "should-not-be-read",
+          "auth_method": "consumer"
+        }
+        """);
+
+        Assert.NotNull(cred);
+        Assert.Equal("ya29.sample", cred!.AccessToken);
+        Assert.Equal("1//sample", cred.RefreshToken);
+        Assert.Equal(new DateTimeOffset(2026, 8, 11, 17, 36, 25, TimeSpan.Zero), cred.ExpiresAt);
+    }
+
+    [Fact]
+    public void ParseCredentialBlob_ReturnsNull_WhenTokenObjectMissing()
+    {
+        Assert.Null(AntigravityUsageMonitor.ParseCredentialBlob("""{"auth_method":"consumer"}"""));
+    }
+
+    [Fact]
+    public void ParseCredentialBlob_KeepsRefreshToken_WhenExpiryUnparsable()
+    {
+        // 만료 시각을 못 읽으면 access_token 을 신뢰하지 않고 갱신 경로로 가야 한다.
+        var cred = AntigravityUsageMonitor.ParseCredentialBlob("""
+        {"token": {"access_token": "ya29.sample", "refresh_token": "1//sample", "expiry": "0001-01-01"}}
+        """);
+
+        Assert.NotNull(cred);
+        Assert.Equal("1//sample", cred!.RefreshToken);
+    }
+}

--- a/ClaudeUsageTray.Tests/ViewModels/AntigravityApplyQuotaTests.cs
+++ b/ClaudeUsageTray.Tests/ViewModels/AntigravityApplyQuotaTests.cs
@@ -11,7 +11,11 @@ namespace ClaudeUsageTray.Tests.ViewModels;
 /// <summary>
 /// 화면에 올라가는 규칙(무엇을 보여주고, 트레이 게이지에 어떤 값을 쓰는지)만 검증한다.
 /// ApplyQuota 는 로컬 조회와 다른 PC 동기화가 함께 지나가는 지점이라 표시가 어긋나면 양쪽이 같이 틀어진다.
+///
+/// 언어를 바꿔 확인하는 항목이 있어 Loc 을 만지는 다른 테스트와 같은 컬렉션에 둔다.
+/// Loc.Lang 은 프로세스 전역이라 병렬로 돌면 서로의 단정을 깨뜨린다.
 /// </summary>
+[Collection("WpfTests")]
 public sealed class AntigravityApplyQuotaTests
 {
     private static readonly DateTimeOffset Reset = DateTimeOffset.UtcNow.AddHours(3);
@@ -86,6 +90,59 @@ public sealed class AntigravityApplyQuotaTests
             ], null, null);
 
             Assert.Equal(["3p-5h", "gemini-5h", "gemini-weekly"], vm.Models.Select(m => m.ModelId));
+        }
+    }
+
+    [Theory]
+    [InlineData("ko", "gemini-weekly", "weekly", "Gemini 모델 · 주간 잔여량")]
+    [InlineData("ko", "3p-5h", "5h", "Claude · GPT 모델 · 5시간 잔여량")]
+    [InlineData("ja", "gemini-5h", "5h", "Gemini モデル · 5時間残量")]
+    [InlineData("zh", "3p-weekly", "weekly", "Claude 和 GPT 模型 · 每周剩余")]
+    [InlineData("en", "gemini-weekly", "weekly", "Gemini Models · Weekly Limit Remaining")]
+    public void ResolveDisplayName_UsesAppLanguage_ForKnownBuckets(
+        string lang, string bucketId, string window, string expected)
+    {
+        var previous = Loc.CurrentLang;
+        try
+        {
+            Loc.SetLanguage(lang);
+
+            var label = AntigravityViewModel.ResolveDisplayName(new AntigravityModelQuota
+            {
+                ModelId = bucketId,
+                TokenType = window,
+                DisplayName = "Gemini Models · Weekly Limit Remaining",   // 서버가 준 영어 문구
+            });
+
+            Assert.Equal(expected, label);
+        }
+        finally
+        {
+            Loc.SetLanguage(previous);
+        }
+    }
+
+    [Fact]
+    public void ResolveDisplayName_KeepsServerText_ForUnknownBucket()
+    {
+        var previous = Loc.CurrentLang;
+        try
+        {
+            Loc.SetLanguage("ko");
+
+            // 새 그룹이나 새 창 종류가 생기면 번역이 없으므로 서버 문구를 그대로 보여준다.
+            var label = AntigravityViewModel.ResolveDisplayName(new AntigravityModelQuota
+            {
+                ModelId = "future-group-monthly",
+                TokenType = "monthly",
+                DisplayName = "Future Group · Monthly Limit",
+            });
+
+            Assert.Equal("Future Group · Monthly Limit", label);
+        }
+        finally
+        {
+            Loc.SetLanguage(previous);
         }
     }
 

--- a/ClaudeUsageTray.Tests/ViewModels/AntigravityApplyQuotaTests.cs
+++ b/ClaudeUsageTray.Tests/ViewModels/AntigravityApplyQuotaTests.cs
@@ -147,6 +147,53 @@ public sealed class AntigravityApplyQuotaTests
     }
 
     [Fact]
+    public void RefreshLocalizedLabels_RebuildsRows_WhenLanguageChangesAfterLoad()
+    {
+        var previous = Loc.CurrentLang;
+        var vm = CreateVm(out var monitor);
+        using (monitor)
+        {
+            try
+            {
+                Loc.SetLanguage("en");
+                vm.ApplyQuota(
+                [
+                    new AntigravityModelQuota
+                    {
+                        ModelId = "gemini-weekly", TokenType = "weekly",
+                        RemainingFraction = 0.4, ResetTime = Reset,
+                    },
+                ], null, null);
+                Assert.Equal("Gemini Models · Weekly Limit Remaining", vm.Models[0].DisplayName);
+
+                // 행 문구는 만들 때 정해지므로, 언어만 바꾸면 다음 조회까지 옛 언어로 남는다.
+                Loc.SetLanguage("ko");
+                vm.RefreshLocalizedLabels();
+
+                Assert.Equal("Gemini 모델 · 주간 잔여량", vm.Models[0].DisplayName);
+                Assert.Contains("사용", vm.Models[0].UsageLabel);
+            }
+            finally
+            {
+                Loc.SetLanguage(previous);
+            }
+        }
+    }
+
+    [Fact]
+    public void RefreshLocalizedLabels_DoesNothing_WhenNoQuotaLoaded()
+    {
+        var vm = CreateVm(out var monitor);
+        using (monitor)
+        {
+            vm.RefreshLocalizedLabels();
+
+            Assert.False(vm.HasData);
+            Assert.Empty(vm.Models);
+        }
+    }
+
+    [Fact]
     public void ApplyQuota_FallsBackToFormattedId_WhenDisplayNameMissing()
     {
         var vm = CreateVm(out var monitor);

--- a/ClaudeUsageTray.Tests/ViewModels/AntigravityApplyQuotaTests.cs
+++ b/ClaudeUsageTray.Tests/ViewModels/AntigravityApplyQuotaTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ClaudeUsageTray.Models;
+using ClaudeUsageTray.Services;
+using ClaudeUsageTray.ViewModels;
+using Xunit;
+
+namespace ClaudeUsageTray.Tests.ViewModels;
+
+/// <summary>
+/// 화면에 올라가는 규칙(무엇을 보여주고, 트레이 게이지에 어떤 값을 쓰는지)만 검증한다.
+/// ApplyQuota 는 로컬 조회와 다른 PC 동기화가 함께 지나가는 지점이라 표시가 어긋나면 양쪽이 같이 틀어진다.
+/// </summary>
+public sealed class AntigravityApplyQuotaTests
+{
+    private static readonly DateTimeOffset Reset = DateTimeOffset.UtcNow.AddHours(3);
+
+    private static AntigravityModelQuota Bucket(string id, double remaining, string displayName = "",
+                                                DateTimeOffset? reset = null) =>
+        new()
+        {
+            ModelId = id,
+            RemainingFraction = remaining,
+            DisplayName = displayName,
+            ResetTime = reset ?? Reset,
+        };
+
+    private static AntigravityViewModel CreateVm(out AntigravityUsageMonitor monitor)
+    {
+        monitor = new AntigravityUsageMonitor();
+        return new AntigravityViewModel(monitor);
+    }
+
+    [Fact]
+    public void ApplyQuota_KeepsUntouchedWindows_SoTheGaugeMatchesTheAntigravityScreen()
+    {
+        var vm = CreateVm(out var monitor);
+        using (monitor)
+        {
+            // 아직 아무것도 쓰지 않은 주 — Antigravity 화면은 이때도 100% 게이지 네 칸을 보여준다.
+            vm.ApplyQuota(
+            [
+                Bucket("gemini-weekly", 1.0, "Gemini Models · Weekly Limit"),
+                Bucket("gemini-5h",     1.0, "Gemini Models · Five Hour Limit"),
+                Bucket("3p-weekly",     1.0, "Claude and GPT models · Weekly Limit"),
+                Bucket("3p-5h",         1.0, "Claude and GPT models · Five Hour Limit"),
+            ], "Antigravity", "Google AI Pro");
+
+            Assert.True(vm.HasData);
+            Assert.Equal(4, vm.Models.Count);
+            Assert.All(vm.Models, row => Assert.Equal(0, row.UsagePercent));
+            Assert.Equal(0, vm.Percent);
+            Assert.Equal("Google AI Pro", vm.PaidTierName);
+        }
+    }
+
+    [Fact]
+    public void ApplyQuota_ReportsWorstWindow_NotTheAverage()
+    {
+        var vm = CreateVm(out var monitor);
+        using (monitor)
+        {
+            // 주간은 90% 썼고 5시간 창은 아직 안 썼다. 평균(45%)은 실제 제약을 가린다.
+            vm.ApplyQuota(
+            [
+                Bucket("gemini-weekly", 0.10),
+                Bucket("gemini-5h",     1.00),
+            ], null, null);
+
+            Assert.Equal(0.90, vm.Percent, 3);
+        }
+    }
+
+    [Fact]
+    public void ApplyQuota_SortsMostConsumedFirst()
+    {
+        var vm = CreateVm(out var monitor);
+        using (monitor)
+        {
+            vm.ApplyQuota(
+            [
+                Bucket("gemini-weekly", 0.80),   // 20% 사용
+                Bucket("3p-5h",         0.10),   // 90% 사용
+                Bucket("gemini-5h",     0.50),   // 50% 사용
+            ], null, null);
+
+            Assert.Equal(["3p-5h", "gemini-5h", "gemini-weekly"], vm.Models.Select(m => m.ModelId));
+        }
+    }
+
+    [Fact]
+    public void ApplyQuota_FallsBackToFormattedId_WhenDisplayNameMissing()
+    {
+        var vm = CreateVm(out var monitor);
+        using (monitor)
+        {
+            // 표시 이름을 함께 올리지 않던 버전이 동기화한 값.
+            vm.ApplyQuota([Bucket("gemini-2.5-pro", 0.5)], null, null);
+
+            Assert.Equal(AntigravityViewModel.FormatModelName("gemini-2.5-pro"), vm.Models[0].DisplayName);
+        }
+    }
+
+    [Fact]
+    public void ApplyQuota_PrefersServerDisplayName_WhenPresent()
+    {
+        var vm = CreateVm(out var monitor);
+        using (monitor)
+        {
+            vm.ApplyQuota([Bucket("3p-weekly", 0.5, "Claude and GPT models · Weekly Limit")], null, null);
+
+            Assert.Equal("Claude and GPT models · Weekly Limit", vm.Models[0].DisplayName);
+        }
+    }
+
+    [Fact]
+    public void ApplyQuota_SkipsRows_WithoutResetTimeOrInternalPrefix()
+    {
+        var vm = CreateVm(out var monitor);
+        using (monitor)
+        {
+            vm.ApplyQuota(
+            [
+                Bucket("gemini-weekly", 0.5),
+                new AntigravityModelQuota { ModelId = "no-reset", RemainingFraction = 0.5, ResetTime = null },
+                Bucket("chat_internal", 0.1),
+                Bucket("tab_internal",  0.1),
+            ], null, null);
+
+            Assert.Equal(["gemini-weekly"], vm.Models.Select(m => m.ModelId));
+            // 걸러진 행은 트레이 게이지 값에도 반영되지 않는다.
+            Assert.Equal(0.5, vm.Percent, 3);
+        }
+    }
+
+    [Fact]
+    public void ApplyQuota_ClearsPreviousError()
+    {
+        var vm = CreateVm(out var monitor);
+        using (monitor)
+        {
+            vm.HasError = true;
+            vm.ErrorMessage = "stale failure";
+
+            vm.ApplyQuota([Bucket("gemini-weekly", 1.0)], null, null);
+
+            Assert.False(vm.HasError);
+            Assert.Equal("", vm.ErrorMessage);
+        }
+    }
+
+    [Fact]
+    public void ApplyQuota_LeavesListEmpty_WhenNothingUsable()
+    {
+        var vm = CreateVm(out var monitor);
+        using (monitor)
+        {
+            vm.ApplyQuota(new List<AntigravityModelQuota>(), null, null);
+
+            Assert.Empty(vm.Models);
+            Assert.Equal(0, vm.Percent);
+        }
+    }
+}

--- a/ClaudeUsageTray.Tests/ViewModels/ViewModelInternalTests.cs
+++ b/ClaudeUsageTray.Tests/ViewModels/ViewModelInternalTests.cs
@@ -474,6 +474,8 @@ public class UsageSyncQuotaPolicyTests
         Assert.Equal("gemini-3-pro", vm.Models[0].ModelId);   // 사용률 내림차순
         Assert.Equal(0.75, vm.Models[0].UsagePercent, 6);
         Assert.Equal(0.10, vm.Models[1].UsagePercent, 6);
-        Assert.Equal((0.75 + 0.10) / 2, vm.Percent, 6);       // 평균은 남은 두 모델 기준
+        // 한도는 창마다 따로 걸리므로 평균이 아니라 가장 많이 쓴 쪽을 대표값으로 쓴다.
+        // 평균이면 여기서 42.5% 가 되어, 이미 75% 를 쓴 제약이 화면에서 가려진다.
+        Assert.Equal(0.75, vm.Percent, 6);
     }
 }

--- a/ClaudeUsageTray/ClaudeUsageTray.csproj
+++ b/ClaudeUsageTray/ClaudeUsageTray.csproj
@@ -7,8 +7,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>1.38.11</Version>
-    <AssemblyVersion>1.38.11</AssemblyVersion>
+    <Version>1.39.0</Version>
+    <AssemblyVersion>1.39.0</AssemblyVersion>
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>false</SelfContained>

--- a/ClaudeUsageTray/Models/AntigravityUsage.cs
+++ b/ClaudeUsageTray/Models/AntigravityUsage.cs
@@ -4,15 +4,27 @@ using System.Collections.Generic;
 namespace ClaudeUsageTray.Models;
 
 /// <summary>
-/// 단일 모델의 quota 버킷.
-/// Antigravity 의 retrieveUserQuota 응답이 모델별로 이 형식으로 옴.
+/// quota 버킷 하나.
+/// Antigravity 의 retrieveUserQuotaSummary 응답에서 모델 그룹(Gemini / Claude·GPT)별로
+/// 주간·5시간 창이 각각 이 형식으로 온다.
 /// </summary>
 public sealed class AntigravityModelQuota
 {
+    /// <summary>버킷 식별자. 예: "gemini-weekly", "3p-5h".</summary>
     public string ModelId { get; init; } = "";
-    public string TokenType { get; init; } = "";            // 보통 "REQUESTS"
+
+    /// <summary>창 종류. Summary 응답에서는 "weekly" 또는 "5h".</summary>
+    public string TokenType { get; init; } = "";
+
     public double RemainingFraction { get; init; }           // 0.0 ~ 1.0 (잔여 비율)
     public DateTimeOffset? ResetTime { get; init; }
+
+    /// <summary>
+    /// 서버가 내려준 표시 이름. 예: "Gemini Models · Weekly Limit".
+    /// 비어 있으면 화면에서 <see cref="ModelId"/> 를 사람이 읽을 형태로 바꿔 쓴다
+    /// (구버전이 동기화로 올린 모델별 값이 이 경우다).
+    /// </summary>
+    public string DisplayName { get; init; } = "";
 }
 
 /// <summary>
@@ -23,6 +35,13 @@ public sealed class AntigravitySnapshot
 {
     public bool HasData { get; init; }
     public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// 조회하지 못한 이유가 "이 PC 에는 볼 것이 없다" 인 경우 true.
+    /// Antigravity 미설치·미로그인·세션 만료가 여기 해당하며, 화면에는 빨간 오류 대신 섹션 숨김으로 나타난다.
+    /// 실패 사유를 문구로 판별하면 문구를 고칠 때 조용히 깨지므로 스냅샷이 직접 들고 있는다.
+    /// </summary>
+    public bool IsInformational { get; init; }
     public string? TierName { get; init; }                   // 예: "Gemini Code Assist"
     public string? PaidTierName { get; init; }               // 예: "Gemini Code Assist in Google One AI Pro"
     public string? UserEmail { get; init; }

--- a/ClaudeUsageTray/Models/UsageSyncModels.cs
+++ b/ClaudeUsageTray/Models/UsageSyncModels.cs
@@ -72,6 +72,9 @@ public sealed class UsageSyncModelQuota
 
     /// <summary>서버가 내려준 표시 이름. 이 필드가 없던 버전이 올린 스냅샷에서는 비어 있다.</summary>
     public string DisplayName { get; set; } = "";
+
+    /// <summary>창 종류("weekly", "5h"). 받는 쪽에서 이름을 자기 언어로 부르는 데 쓴다.</summary>
+    public string Window { get; set; } = "";
 }
 
 public sealed class UsageSyncOpenCodeQuota

--- a/ClaudeUsageTray/Models/UsageSyncModels.cs
+++ b/ClaudeUsageTray/Models/UsageSyncModels.cs
@@ -69,6 +69,9 @@ public sealed class UsageSyncModelQuota
     public string ModelId { get; set; } = "";
     public double RemainingFraction { get; set; }
     public DateTimeOffset? ResetAt { get; set; }
+
+    /// <summary>서버가 내려준 표시 이름. 이 필드가 없던 버전이 올린 스냅샷에서는 비어 있다.</summary>
+    public string DisplayName { get; set; } = "";
 }
 
 public sealed class UsageSyncOpenCodeQuota

--- a/ClaudeUsageTray/Services/AntigravityOAuthClientLocator.cs
+++ b/ClaudeUsageTray/Services/AntigravityOAuthClientLocator.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace ClaudeUsageTray.Services;
+
+/// <summary>OAuth client 자격 증명 한 쌍. 바이너리에서 뽑은 후보이거나 사용자가 적어 둔 값이다.</summary>
+public sealed record AntigravityOAuthClient(string ClientId, string ClientSecret);
+
+/// <summary>
+/// 설치된 Antigravity 의 <c>language_server.exe</c> 에서 OAuth client_id/secret 을 찾아낸다.
+///
+/// 자격 증명 관리자에 남아 있는 access_token 이 아직 살아 있으면 이 경로는 쓰이지 않는다.
+/// 토큰이 만료돼 refresh 가 필요할 때만 호출된다.
+///
+/// client_id 와 secret 은 바이너리에 평문으로 박혀 있지만 인접한 다른 문자열과 경계 없이 붙어 있어서,
+/// 문자 종류만으로 앞뒤를 자르면 옆 문자열을 함께 먹는다. 그래서 Google 이 정한 형식
+/// (<c>{숫자}-{소문자숫자}.apps.googleusercontent.com</c>, <c>GOCSPX-</c> + 28자) 을 그대로 경계로 쓴다.
+/// </summary>
+internal static class AntigravityOAuthClientLocator
+{
+    private const string IdSuffix = ".apps.googleusercontent.com";
+    private const string SecretPrefix = "GOCSPX-";
+
+    /// <summary>Google client secret 은 접두사 뒤 28자 고정이다. 경계가 없는 바이너리에서는 이 길이가 유일한 단서다.</summary>
+    private const int SecretBodyLength = 28;
+
+    private const int MinProjectDigits = 6;
+    private const int MinProjectHash = 15;
+
+    /// <summary>설치된 language_server.exe 경로. 없으면 null.</summary>
+    internal static string? FindLanguageServerPath()
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrEmpty(localAppData)) return null;
+
+        var path = Path.Combine(localAppData, "Programs", "antigravity", "resources", "bin", "language_server.exe");
+        return File.Exists(path) ? path : null;
+    }
+
+    /// <summary>
+    /// 바이너리를 훑어 client_id 와 secret 후보를 모아 가능한 조합을 만든다.
+    /// 어느 조합이 실제로 유효한지는 여기서 알 수 없으므로 (짝이 기록돼 있지 않다) 호출부가 차례로 시도한다.
+    /// 보통 각각 2개씩이라 조합은 네 개를 넘지 않는다.
+    /// </summary>
+    internal static IReadOnlyList<AntigravityOAuthClient> ScanCandidates(Stream stream)
+    {
+        var ids = new List<string>();
+        var secrets = new List<string>();
+        ScanRaw(stream, ids, secrets);
+
+        var pairs = new List<AntigravityOAuthClient>(ids.Count * secrets.Count);
+        foreach (var id in ids)
+            foreach (var secret in secrets)
+                pairs.Add(new AntigravityOAuthClient(id, secret));
+        return pairs;
+    }
+
+    private static void ScanRaw(Stream stream, List<string> ids, List<string> secrets)
+    {
+        byte[] suffix = Encoding.ASCII.GetBytes(IdSuffix);
+        byte[] prefix = Encoding.ASCII.GetBytes(SecretPrefix);
+
+        // 청크 경계에 걸친 문자열을 놓치지 않도록 앞 chunk 의 꼬리를 물고 간다.
+        const int ChunkSize = 4 * 1024 * 1024;
+        int overlap = Math.Max(suffix.Length, prefix.Length + SecretBodyLength) + 128;
+
+        var buffer = new byte[ChunkSize + overlap];
+        int carry = 0;
+
+        while (true)
+        {
+            int read = stream.Read(buffer, carry, ChunkSize);
+            if (read <= 0) break;
+
+            int length = carry + read;
+            ScanBuffer(buffer, length, suffix, prefix, ids, secrets);
+
+            carry = Math.Min(overlap, length);
+            Buffer.BlockCopy(buffer, length - carry, buffer, 0, carry);
+        }
+    }
+
+    private static void ScanBuffer(byte[] buffer, int length, byte[] suffix, byte[] prefix,
+                                   List<string> ids, List<string> secrets)
+    {
+        for (int i = 0; i + suffix.Length <= length; i++)
+        {
+            if (!Matches(buffer, i, suffix)) continue;
+            var id = ReadClientIdBackwards(buffer, i);
+            if (id is not null && !ids.Contains(id)) ids.Add(id);
+        }
+
+        for (int i = 0; i + prefix.Length + SecretBodyLength <= length; i++)
+        {
+            if (!Matches(buffer, i, prefix)) continue;
+
+            bool bodyIsSecretChars = true;
+            for (int k = 0; k < SecretBodyLength; k++)
+            {
+                if (!IsSecretChar(buffer[i + prefix.Length + k])) { bodyIsSecretChars = false; break; }
+            }
+            if (!bodyIsSecretChars) continue;
+
+            var secret = Encoding.ASCII.GetString(buffer, i, prefix.Length + SecretBodyLength);
+            if (!secrets.Contains(secret)) secrets.Add(secret);
+        }
+    }
+
+    /// <summary>
+    /// <c>.apps.googleusercontent.com</c> 앞에서 거꾸로 읽어 client_id 를 복원한다.
+    /// 형식(해시 - 하이픈 - 숫자)에서 벗어나면 앞 문자열을 먹은 것이므로 버린다.
+    /// </summary>
+    private static string? ReadClientIdBackwards(byte[] buffer, int suffixStart)
+    {
+        int hashStart = suffixStart;
+        while (hashStart > 0 && IsLowerAlphanumeric(buffer[hashStart - 1])) hashStart--;
+        if (suffixStart - hashStart < MinProjectHash) return null;
+
+        int hyphen = hashStart - 1;
+        if (hyphen <= 0 || buffer[hyphen] != (byte)'-') return null;
+
+        int digitsStart = hyphen;
+        while (digitsStart > 0 && IsDigit(buffer[digitsStart - 1])) digitsStart--;
+        if (hyphen - digitsStart < MinProjectDigits) return null;
+
+        return Encoding.ASCII.GetString(buffer, digitsStart, suffixStart - digitsStart) + IdSuffix;
+    }
+
+    private static bool Matches(byte[] buffer, int offset, byte[] pattern)
+    {
+        for (int k = 0; k < pattern.Length; k++)
+        {
+            if (buffer[offset + k] != pattern[k]) return false;
+        }
+        return true;
+    }
+
+    private static bool IsDigit(byte b) => b >= (byte)'0' && b <= (byte)'9';
+
+    private static bool IsLowerAlphanumeric(byte b) =>
+        (b >= (byte)'a' && b <= (byte)'z') || IsDigit(b);
+
+    private static bool IsSecretChar(byte b) =>
+        (b >= (byte)'A' && b <= (byte)'Z') || (b >= (byte)'a' && b <= (byte)'z') ||
+        IsDigit(b) || b == (byte)'_' || b == (byte)'-';
+}

--- a/ClaudeUsageTray/Services/AntigravityUsageMonitor.cs
+++ b/ClaudeUsageTray/Services/AntigravityUsageMonitor.cs
@@ -425,8 +425,14 @@ public sealed class AntigravityUsageMonitor : IDisposable
             }, new JsonSerializerOptions { WriteIndented = true });
 
             // 쓰다 만 파일이 남지 않도록 임시 파일에 쓴 뒤 옮긴다.
+            // 임시 경로가 고정이라 다른 인스턴스가 같은 파일을 보고 있을 수 있으므로 공유 모드로 연다
+            // (여기서 IOException 이 나면 캐시를 못 남겨 다음 실행에서 바이너리를 또 훑게 된다).
             var temp = ClientConfigPath + ".tmp";
-            File.WriteAllText(temp, json);
+            using (var fs = new FileStream(temp, FileMode.Create, FileAccess.Write, FileShare.ReadWrite))
+            using (var writer = new StreamWriter(fs, Encoding.UTF8))
+            {
+                writer.Write(json);
+            }
             File.Move(temp, ClientConfigPath, overwrite: true);
         }
         catch (Exception ex)

--- a/ClaudeUsageTray/Services/AntigravityUsageMonitor.cs
+++ b/ClaudeUsageTray/Services/AntigravityUsageMonitor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
@@ -59,6 +60,13 @@ public sealed class AntigravityUsageMonitor : IDisposable
     private string? _accessToken;
     private DateTimeOffset _accessExpiresAt = DateTimeOffset.MinValue;
     private readonly SemaphoreSlim _refreshLock = new(1, 1);
+
+    /// <summary>
+    /// 서버가 거부한 자격 증명 관리자 토큰. 폐기된 토큰은 기록된 만료 시각이 아직 남아 있어도 다시 쓰면 안 된다.
+    /// 그대로 두면 만료 시각이 지날 때까지 매번 401 을 받으며 갱신 경로로 넘어가지 못한다.
+    /// Antigravity 가 새 토큰을 저장하면 값이 달라지므로 저절로 풀린다.
+    /// </summary>
+    private string? _rejectedStoredToken;
 
     // 바이너리 스캔은 한 번만 시도한다 (144MB, 약 1.5초).
     private bool _clientLookupAttempted;
@@ -234,9 +242,13 @@ public sealed class AntigravityUsageMonitor : IDisposable
             using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseContentRead, ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
             {
-                // 401 → 다음 호출에서 다시 갱신하도록 캐시를 버린다.
                 if (resp.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                {
+                    // 다음 호출에서 다시 갱신하도록 캐시를 버리고,
+                    // 방금 거부당한 토큰은 만료 시각이 남아 있어도 재사용하지 않는다.
                     _accessExpiresAt = DateTimeOffset.MinValue;
+                    _rejectedStoredToken = accessToken;
+                }
                 return null;
             }
 
@@ -261,6 +273,7 @@ public sealed class AntigravityUsageMonitor : IDisposable
 
         // Antigravity 가 직접 갱신해 둔 토큰이 아직 살아 있으면 그대로 쓴다. 가장 흔한 경로다.
         if (!string.IsNullOrEmpty(cred.AccessToken) &&
+            !string.Equals(cred.AccessToken, _rejectedStoredToken, StringComparison.Ordinal) &&
             cred.ExpiresAt is { } expiry &&
             DateTimeOffset.UtcNow + TokenRefreshSkew < expiry)
         {
@@ -276,7 +289,7 @@ public sealed class AntigravityUsageMonitor : IDisposable
             if (IsCachedTokenUsable())
                 return _accessToken;
 
-            foreach (var client in EnumerateClientCandidates())
+            foreach (var client in await LoadClientCandidatesAsync().ConfigureAwait(false))
             {
                 var token = await TryRefreshAsync(client, cred.RefreshToken, ct).ConfigureAwait(false);
                 if (token is null) continue;
@@ -297,39 +310,39 @@ public sealed class AntigravityUsageMonitor : IDisposable
     private bool IsCachedTokenUsable() =>
         !string.IsNullOrEmpty(_accessToken) && DateTimeOffset.UtcNow + TokenRefreshSkew < _accessExpiresAt;
 
-    /// <summary>사용자가 적어 둔 값을 먼저 쓰고, 없으면 설치된 바이너리에서 찾아낸 후보를 차례로 준다.</summary>
-    private IEnumerable<AntigravityOAuthClient> EnumerateClientCandidates()
+    /// <summary>사용자가 적어 둔 값을 먼저 쓰고, 없으면 설치된 바이너리에서 찾아낸 후보를 뒤에 붙인다.</summary>
+    private async Task<IReadOnlyList<AntigravityOAuthClient>> LoadClientCandidatesAsync()
     {
-        var configured = ReadClientConfig();
-        if (configured is not null) yield return configured;
+        var candidates = new List<AntigravityOAuthClient>();
 
-        if (_clientLookupAttempted) yield break;
+        var configured = ReadClientConfig();
+        if (configured is not null) candidates.Add(configured);
+
+        if (_clientLookupAttempted) return candidates;
         _clientLookupAttempted = true;
 
         var path = AntigravityOAuthClientLocator.FindLanguageServerPath();
-        if (path is null) yield break;
+        if (path is null) return candidates;
 
-        IReadOnlyList<AntigravityOAuthClient> candidates;
         try
         {
-            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            candidates = AntigravityOAuthClientLocator.ScanCandidates(fs);
+            // 144MB 를 순차로 훑는 작업이라 호출한 스레드에서 그대로 돌리면 안 된다.
+            // 수동 새로고침은 UI 스레드에서 시작되므로 그동안 트레이 화면이 멈춘다.
+            var scanned = await Task.Run(() =>
+            {
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                return AntigravityOAuthClientLocator.ScanCandidates(fs);
+            }).ConfigureAwait(false);
+
+            // 이미 실패한 조합을 다시 시도하지 않는다.
+            candidates.AddRange(scanned.Where(c => c != configured));
         }
-        catch
+        catch (Exception ex)
         {
-            yield break;
+            System.Diagnostics.Trace.TraceWarning($"[AntigravityUsageMonitor] client lookup failed: {ex.Message}");
         }
 
-        foreach (var candidate in candidates)
-        {
-            if (configured is not null &&
-                configured.ClientId == candidate.ClientId &&
-                configured.ClientSecret == candidate.ClientSecret)
-            {
-                continue;   // 방금 실패한 조합을 다시 시도하지 않는다.
-            }
-            yield return candidate;
-        }
+        return candidates;
     }
 
     /// <summary>갱신에 성공하면 access_token, 자격 증명이 틀리면 null. 네트워크 오류는 예외로 올린다.</summary>

--- a/ClaudeUsageTray/Services/AntigravityUsageMonitor.cs
+++ b/ClaudeUsageTray/Services/AntigravityUsageMonitor.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Net.Http.Json;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
@@ -14,32 +13,41 @@ using ClaudeUsageTray.Models;
 namespace ClaudeUsageTray.Services;
 
 /// <summary>
-/// Antigravity (Google's Gemini Code Assist desktop IDE, fork of Codeium/Windsurf) 의
-/// 모델별 quota 데이터를 가져오는 monitor.
+/// Antigravity (Google 의 Gemini Code Assist 데스크톱 IDE) 의 사용량 게이지를 가져오는 monitor.
 ///
 /// 흐름:
-///  1. Windows Credential Manager 의 "gemini:antigravity" 항목에서 refresh_token 읽기.
-///  2. oauth2.googleapis.com 에 client_id/secret 으로 refresh → 새 access_token.
-///  3. daily-cloudcode-pa.googleapis.com 의 v1internal:retrieveUserQuota 호출 → 모델별 quota.
-///  4. v1internal:loadCodeAssist 도 호출해 tier 정보 함께 노출.
+///  1. Windows 자격 증명 관리자의 "gemini:antigravity" 항목에서 토큰을 읽는다.
+///  2. 저장된 access_token 이 아직 유효하면 그대로 쓴다. 이 경우 OAuth client 자격 증명이 필요 없다.
+///  3. 만료됐으면 refresh_token 으로 갱신한다. 이때만 client_id/secret 이 필요하며,
+///     사용자가 적어 둔 파일이 없으면 설치된 language_server.exe 에서 찾아낸다.
+///  4. v1internal:retrieveUserQuotaSummary 로 그룹별(Gemini / Claude·GPT) 주간·5시간 잔여량을 받는다.
+///     Antigravity 앱의 "Models &amp; Usage" 화면이 그리는 값이 이것이다.
+///  5. v1internal:loadCodeAssist 로 tier 표기를 함께 받는다.
 ///
-/// 모든 단계는 비공식 API. Antigravity 마이너 업데이트로 client_id/secret 가 바뀔 수 있음.
-/// 그 경우 사용자가 새 PC dump 떠서 secret 만 교체하면 다시 작동.
+/// Antigravity 를 실행하지 않아도 동작한다. 앱의 로컬 서버가 아니라 Google 백엔드를 직접 부르기 때문이다.
+///
+/// 모든 단계가 비공식 API 다. 클라이언트 업데이트로 엔드포인트나 헤더 규칙이 바뀌면 조용히 실패할 수 있으므로,
+/// 실패는 예외 대신 <see cref="AntigravitySnapshot.ErrorMessage"/> 로 돌려보내 섹션만 비운다.
 /// </summary>
 public sealed class AntigravityUsageMonitor : IDisposable
 {
     private const string CredentialTarget = "gemini:antigravity";
 
-    private const string TokenEndpoint    = "https://oauth2.googleapis.com/token";
-    private const string CloudCodeBase    = "https://daily-cloudcode-pa.googleapis.com/v1internal";
+    private const string TokenEndpoint = "https://oauth2.googleapis.com/token";
+    private const string CloudCodeBase = "https://daily-cloudcode-pa.googleapis.com/v1internal";
+
+    /// <summary>
+    /// 클라이언트 신원. 이 형식의 User-Agent 가 없으면 retrieveUserQuotaSummary 가 403 을 준다
+    /// (retrieveUserQuota 는 없어도 통과하지만 화면과 다른 모델별 값이라 쓰지 않는다).
+    /// 서버가 버전 값 자체를 검사하지는 않는다.
+    /// </summary>
+    private const string ClientUserAgent = "antigravity/2.6.0";
 
     private static readonly TimeSpan TokenRefreshSkew = TimeSpan.FromMinutes(2);
 
     /// <summary>
-    /// 사용자 PC 의 OAuth client config 파일 경로.
-    /// 형식: <c>{"client_id": "...", "client_secret": "..."}</c>.
-    /// 파일이 없으면 monitor 가 즉시 setup-needed 상태로 폴백 (UI 섹션 숨김).
-    /// 값 추출 방법은 README 의 "Antigravity 통합" 섹션 참조.
+    /// 사용자가 직접 적어 둔 OAuth client 파일. 형식: <c>{"client_id": "...", "client_secret": "..."}</c>.
+    /// 이제는 필수가 아니며, 바이너리에서 찾아낸 값을 다음 실행에서 다시 찾지 않으려고 여기에 저장하기도 한다.
     /// </summary>
     private static readonly string ClientConfigPath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
@@ -47,15 +55,18 @@ public sealed class AntigravityUsageMonitor : IDisposable
 
     private readonly HttpClient _http;
 
-    // In-memory cached access_token (avoid hitting Google's token endpoint on every poll).
+    // refresh 로 받은 access_token 은 메모리에만 둔다 (자격 증명 관리자 쪽은 Antigravity 가 관리한다).
     private string? _accessToken;
     private DateTimeOffset _accessExpiresAt = DateTimeOffset.MinValue;
     private readonly SemaphoreSlim _refreshLock = new(1, 1);
 
+    // 바이너리 스캔은 한 번만 시도한다 (144MB, 약 1.5초).
+    private bool _clientLookupAttempted;
+
     public AntigravityUsageMonitor()
     {
-        _http = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
-        _http.DefaultRequestHeaders.UserAgent.ParseAdd("Antigravity/2.0.6 (windows x64)");
+        _http = new HttpClient { Timeout = TimeSpan.FromSeconds(AppConstants.AuthTimeoutSeconds) };
+        _http.DefaultRequestHeaders.UserAgent.ParseAdd(ClientUserAgent);
     }
 
     public void Dispose()
@@ -66,69 +77,61 @@ public sealed class AntigravityUsageMonitor : IDisposable
 
     public async Task<AntigravitySnapshot> GetSnapshotAsync(CancellationToken ct = default)
     {
-        // 0. OAuth client 설정 — 없으면 setup-needed.
-        OAuthClientConfig? client;
+        // 1. 자격 증명 관리자 — Antigravity 미설치/미로그인 환경에서는 조용히 패스한다.
+        StoredCredential? cred;
         try
         {
-            client = ReadClientConfig();
+            cred = ReadCredStore();
         }
         catch (Exception ex)
         {
-            return new AntigravitySnapshot { ErrorMessage = $"client config read failed: {ex.Message}" };
-        }
-        if (client is null)
-            return new AntigravitySnapshot { ErrorMessage = "Antigravity OAuth client not configured" };
-
-        // 1. credstore 가 있는지부터 — Antigravity 미설치/미로그인 환경에서는 조용히 패스.
-        string? refreshToken;
-        string? userEmail = null;
-        try
-        {
-            var cred = ReadCredStore();
-            if (cred is null)
-                return new AntigravitySnapshot { ErrorMessage = "Antigravity not signed in" };
-            refreshToken = cred.RefreshToken;
-        }
-        catch (Exception ex)
-        {
-            return new AntigravitySnapshot { ErrorMessage = $"credstore read failed: {ex.Message}" };
+            return Failure($"credstore read failed: {ex.Message}");
         }
 
-        if (string.IsNullOrEmpty(refreshToken))
-            return new AntigravitySnapshot { ErrorMessage = "no refresh_token in credstore" };
+        if (cred is null)
+            return Informational("Antigravity not signed in");
 
-        // 2. access_token 확보 (캐시 우선).
+        // 2. access_token 확보.
         string accessToken;
         try
         {
-            accessToken = await EnsureAccessTokenAsync(client, refreshToken, ct);
+            var resolved = await ResolveAccessTokenAsync(cred, ct).ConfigureAwait(false);
+            if (resolved is null)
+            {
+                // 저장된 토큰이 만료됐는데 갱신에 쓸 client 자격 증명을 찾지 못한 상태.
+                // Antigravity 를 한 번 실행하면 앱이 토큰을 새로 발급해 두므로 오류로 취급하지 않는다.
+                return Informational("Antigravity session expired");
+            }
+            accessToken = resolved;
         }
         catch (Exception ex)
         {
-            return new AntigravitySnapshot { ErrorMessage = $"token refresh failed: {ex.Message}" };
+            return Failure($"token refresh failed: {ex.Message}");
         }
 
-        // 3. 두 endpoint 병렬 호출.
-        Task<JsonDocument?> quotaTask = CallV1InternalAsync("retrieveUserQuota", accessToken, ct);
-        Task<JsonDocument?> tierTask  = CallV1InternalAsync("loadCodeAssist", accessToken, ct);
+        // 3. 사용량 요약과 tier 를 함께 받는다.
+        var summaryTask = CallV1InternalAsync("retrieveUserQuotaSummary", accessToken, ct);
+        var tierTask = CallV1InternalAsync("loadCodeAssist", accessToken, ct);
+        await Task.WhenAll(summaryTask, tierTask).ConfigureAwait(false);
 
-        await Task.WhenAll(quotaTask, tierTask).ConfigureAwait(false);
+        using var summaryDoc = summaryTask.Result;
+        using var tierDoc = tierTask.Result;
 
-        using var quotaDoc = quotaTask.Result;
-        using var tierDoc  = tierTask.Result;
+        if (summaryDoc is null)
+            return Failure("retrieveUserQuotaSummary returned no data");
 
-        if (quotaDoc is null)
-            return new AntigravitySnapshot { ErrorMessage = "retrieveUserQuota returned no data" };
+        var buckets = ParseSummary(summaryDoc);
+        if (buckets.Count == 0)
+            return Failure("retrieveUserQuotaSummary returned no buckets");
 
-        var models = ParseBuckets(quotaDoc);
         string? tierName = null, paidTierName = null;
         if (tierDoc is not null)
         {
             var root = tierDoc.RootElement;
-            if (root.TryGetProperty("currentTier", out var ct1) && ct1.TryGetProperty("name", out var n1))
-                tierName = n1.GetString();
-            if (root.TryGetProperty("paidTier", out var pt) && pt.TryGetProperty("name", out var n2))
-                paidTierName = n2.GetString();
+            if (root.TryGetProperty("currentTier", out var current) && current.TryGetProperty("name", out var currentName))
+                tierName = currentName.GetString();
+            if (root.TryGetProperty("paidTier", out var paid) && paid.TryGetProperty("name", out var paidName))
+                paidTierName = paidName.GetString();
         }
 
         return new AntigravitySnapshot
@@ -136,51 +139,93 @@ public sealed class AntigravityUsageMonitor : IDisposable
             HasData = true,
             TierName = tierName,
             PaidTierName = paidTierName,
-            UserEmail = userEmail,
-            Models = models,
+            Models = buckets,
         };
     }
 
-    // ---------- internals ----------
+    private static AntigravitySnapshot Informational(string message) =>
+        new() { ErrorMessage = message, IsInformational = true };
 
-    private static IReadOnlyList<AntigravityModelQuota> ParseBuckets(JsonDocument doc)
+    private static AntigravitySnapshot Failure(string message) =>
+        new() { ErrorMessage = message };
+
+    // ---------- 응답 파싱 ----------
+
+    /// <summary>
+    /// retrieveUserQuotaSummary 응답을 버킷 목록으로 편다.
+    /// 구조: groups[] → buckets[]. 그룹 이름과 버킷 이름을 합쳐 표시 이름을 만든다
+    /// ("Gemini Models" + "Weekly Limit" → "Gemini Models · Weekly Limit").
+    /// </summary>
+    internal static IReadOnlyList<AntigravityModelQuota> ParseSummary(JsonDocument doc)
     {
         var list = new List<AntigravityModelQuota>();
-        if (!doc.RootElement.TryGetProperty("buckets", out var buckets) ||
-            buckets.ValueKind != JsonValueKind.Array)
-            return list;
 
-        foreach (var b in buckets.EnumerateArray())
+        var root = doc.RootElement;
+        // 로컬 language server 를 거치면 한 겹 더 감싸여 오므로 양쪽을 모두 받아 준다.
+        if (root.ValueKind == JsonValueKind.Object &&
+            root.TryGetProperty("response", out var wrapped) &&
+            wrapped.ValueKind == JsonValueKind.Object)
         {
-            string modelId = b.TryGetProperty("modelId", out var m) ? (m.GetString() ?? "") : "";
-            string tokenType = b.TryGetProperty("tokenType", out var t) ? (t.GetString() ?? "") : "";
-            double frac = 1.0;
-            if (b.TryGetProperty("remainingFraction", out var r))
-            {
-                if (r.ValueKind == JsonValueKind.Number) r.TryGetDouble(out frac);
-            }
-            DateTimeOffset? reset = null;
-            if (b.TryGetProperty("resetTime", out var rt) && rt.ValueKind == JsonValueKind.String)
-            {
-                if (DateTimeOffset.TryParse(rt.GetString(), null,
-                        System.Globalization.DateTimeStyles.AssumeUniversal, out var parsed))
-                    reset = parsed;
-            }
-            list.Add(new AntigravityModelQuota
-            {
-                ModelId = modelId,
-                TokenType = tokenType,
-                RemainingFraction = Math.Clamp(frac, 0.0, 1.0),
-                ResetTime = reset,
-            });
+            root = wrapped;
         }
+
+        if (root.ValueKind != JsonValueKind.Object ||
+            !root.TryGetProperty("groups", out var groups) ||
+            groups.ValueKind != JsonValueKind.Array)
+        {
+            return list;
+        }
+
+        foreach (var group in groups.EnumerateArray())
+        {
+            string groupName = group.TryGetProperty("displayName", out var gn) ? (gn.GetString() ?? "") : "";
+            if (!group.TryGetProperty("buckets", out var buckets) || buckets.ValueKind != JsonValueKind.Array)
+                continue;
+
+            foreach (var bucket in buckets.EnumerateArray())
+            {
+                string bucketId = bucket.TryGetProperty("bucketId", out var id) ? (id.GetString() ?? "") : "";
+                string window = bucket.TryGetProperty("window", out var w) ? (w.GetString() ?? "") : "";
+                string bucketName = bucket.TryGetProperty("displayName", out var bn) ? (bn.GetString() ?? "") : "";
+
+                double remaining = 1.0;
+                if (bucket.TryGetProperty("remainingFraction", out var frac) && frac.ValueKind == JsonValueKind.Number)
+                    frac.TryGetDouble(out remaining);
+
+                DateTimeOffset? reset = null;
+                if (bucket.TryGetProperty("resetTime", out var rt) && rt.ValueKind == JsonValueKind.String &&
+                    DateTimeOffset.TryParse(rt.GetString(), null,
+                        System.Globalization.DateTimeStyles.AssumeUniversal, out var parsed))
+                {
+                    reset = parsed;
+                }
+
+                list.Add(new AntigravityModelQuota
+                {
+                    ModelId = bucketId,
+                    TokenType = window,
+                    RemainingFraction = Math.Clamp(remaining, 0.0, 1.0),
+                    ResetTime = reset,
+                    DisplayName = ComposeDisplayName(groupName, bucketName),
+                });
+            }
+        }
+
         return list;
     }
 
+    internal static string ComposeDisplayName(string groupName, string bucketName)
+    {
+        if (string.IsNullOrWhiteSpace(groupName)) return bucketName.Trim();
+        if (string.IsNullOrWhiteSpace(bucketName)) return groupName.Trim();
+        return $"{groupName.Trim()} · {bucketName.Trim()}";
+    }
+
+    // ---------- HTTP ----------
+
     private async Task<JsonDocument?> CallV1InternalAsync(string method, string accessToken, CancellationToken ct)
     {
-        var url = $"{CloudCodeBase}:{method}";
-        using var req = new HttpRequestMessage(HttpMethod.Post, url);
+        using var req = new HttpRequestMessage(HttpMethod.Post, $"{CloudCodeBase}:{method}");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
         req.Content = new StringContent("{}", Encoding.UTF8, "application/json");
 
@@ -189,11 +234,12 @@ public sealed class AntigravityUsageMonitor : IDisposable
             using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseContentRead, ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
             {
-                // 401 → 캐시 토큰 무효화 (다음 호출에서 refresh).
+                // 401 → 다음 호출에서 다시 갱신하도록 캐시를 버린다.
                 if (resp.StatusCode == System.Net.HttpStatusCode.Unauthorized)
                     _accessExpiresAt = DateTimeOffset.MinValue;
                 return null;
             }
+
             var stream = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
             return await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
         }
@@ -203,50 +249,44 @@ public sealed class AntigravityUsageMonitor : IDisposable
         }
     }
 
-    private async Task<string> EnsureAccessTokenAsync(OAuthClientConfig client, string refreshToken, CancellationToken ct)
+    // ---------- 토큰 ----------
+
+    /// <summary>
+    /// 쓸 수 있는 access_token 을 돌려준다. 갱신이 필요한데 client 자격 증명을 구하지 못하면 null.
+    /// </summary>
+    private async Task<string?> ResolveAccessTokenAsync(StoredCredential cred, CancellationToken ct)
     {
-        if (!string.IsNullOrEmpty(_accessToken) &&
-            DateTimeOffset.UtcNow + TokenRefreshSkew < _accessExpiresAt)
+        if (IsCachedTokenUsable())
+            return _accessToken;
+
+        // Antigravity 가 직접 갱신해 둔 토큰이 아직 살아 있으면 그대로 쓴다. 가장 흔한 경로다.
+        if (!string.IsNullOrEmpty(cred.AccessToken) &&
+            cred.ExpiresAt is { } expiry &&
+            DateTimeOffset.UtcNow + TokenRefreshSkew < expiry)
         {
-            return _accessToken!;
+            return cred.AccessToken;
         }
+
+        if (string.IsNullOrEmpty(cred.RefreshToken))
+            return null;
 
         await _refreshLock.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            // double-check after taking the lock
-            if (!string.IsNullOrEmpty(_accessToken) &&
-                DateTimeOffset.UtcNow + TokenRefreshSkew < _accessExpiresAt)
+            if (IsCachedTokenUsable())
+                return _accessToken;
+
+            foreach (var client in EnumerateClientCandidates())
             {
-                return _accessToken!;
+                var token = await TryRefreshAsync(client, cred.RefreshToken, ct).ConfigureAwait(false);
+                if (token is null) continue;
+
+                // 통한 조합만 남겨 두면 다음 실행에서 바이너리를 다시 훑지 않는다.
+                TrySaveClientConfig(client);
+                return token;
             }
 
-            var form = new Dictionary<string, string>
-            {
-                ["client_id"]     = client.ClientId,
-                ["client_secret"] = client.ClientSecret,
-                ["grant_type"]    = "refresh_token",
-                ["refresh_token"] = refreshToken,
-            };
-            using var req = new HttpRequestMessage(HttpMethod.Post, TokenEndpoint)
-            {
-                Content = new FormUrlEncodedContent(form),
-            };
-            using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseContentRead, ct).ConfigureAwait(false);
-            if (!resp.IsSuccessStatusCode)
-            {
-                var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-                throw new Exception($"OAuth refresh HTTP {(int)resp.StatusCode}: {Trim(body, 200)}");
-            }
-            using var doc = await JsonDocument.ParseAsync(await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false), cancellationToken: ct).ConfigureAwait(false);
-            var root = doc.RootElement;
-            var at = root.GetProperty("access_token").GetString();
-            int expiresIn = root.TryGetProperty("expires_in", out var ei) ? ei.GetInt32() : 3600;
-            if (string.IsNullOrEmpty(at)) throw new Exception("empty access_token in OAuth response");
-
-            _accessToken = at;
-            _accessExpiresAt = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(expiresIn);
-            return at;
+            return null;
         }
         finally
         {
@@ -254,24 +294,135 @@ public sealed class AntigravityUsageMonitor : IDisposable
         }
     }
 
+    private bool IsCachedTokenUsable() =>
+        !string.IsNullOrEmpty(_accessToken) && DateTimeOffset.UtcNow + TokenRefreshSkew < _accessExpiresAt;
+
+    /// <summary>사용자가 적어 둔 값을 먼저 쓰고, 없으면 설치된 바이너리에서 찾아낸 후보를 차례로 준다.</summary>
+    private IEnumerable<AntigravityOAuthClient> EnumerateClientCandidates()
+    {
+        var configured = ReadClientConfig();
+        if (configured is not null) yield return configured;
+
+        if (_clientLookupAttempted) yield break;
+        _clientLookupAttempted = true;
+
+        var path = AntigravityOAuthClientLocator.FindLanguageServerPath();
+        if (path is null) yield break;
+
+        IReadOnlyList<AntigravityOAuthClient> candidates;
+        try
+        {
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            candidates = AntigravityOAuthClientLocator.ScanCandidates(fs);
+        }
+        catch
+        {
+            yield break;
+        }
+
+        foreach (var candidate in candidates)
+        {
+            if (configured is not null &&
+                configured.ClientId == candidate.ClientId &&
+                configured.ClientSecret == candidate.ClientSecret)
+            {
+                continue;   // 방금 실패한 조합을 다시 시도하지 않는다.
+            }
+            yield return candidate;
+        }
+    }
+
+    /// <summary>갱신에 성공하면 access_token, 자격 증명이 틀리면 null. 네트워크 오류는 예외로 올린다.</summary>
+    private async Task<string?> TryRefreshAsync(AntigravityOAuthClient client, string refreshToken, CancellationToken ct)
+    {
+        var form = new Dictionary<string, string>
+        {
+            ["client_id"] = client.ClientId,
+            ["client_secret"] = client.ClientSecret,
+            ["grant_type"] = "refresh_token",
+            ["refresh_token"] = refreshToken,
+        };
+
+        using var req = new HttpRequestMessage(HttpMethod.Post, TokenEndpoint) { Content = new FormUrlEncodedContent(form) };
+        using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseContentRead, ct).ConfigureAwait(false);
+
+        if (!resp.IsSuccessStatusCode)
+        {
+            // 400/401 은 "이 조합이 아니다" 라는 뜻이므로 다음 후보로 넘어간다.
+            if (resp.StatusCode is System.Net.HttpStatusCode.BadRequest or System.Net.HttpStatusCode.Unauthorized)
+                return null;
+
+            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            throw new HttpRequestException($"OAuth refresh HTTP {(int)resp.StatusCode}: {Trim(body, 200)}");
+        }
+
+        using var stream = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+
+        var token = doc.RootElement.TryGetProperty("access_token", out var at) ? at.GetString() : null;
+        if (string.IsNullOrEmpty(token)) return null;
+
+        int expiresIn = doc.RootElement.TryGetProperty("expires_in", out var ei) && ei.ValueKind == JsonValueKind.Number
+            ? ei.GetInt32()
+            : 3600;
+
+        _accessToken = token;
+        _accessExpiresAt = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(expiresIn);
+        return token;
+    }
+
     private static string Trim(string s, int n) => s.Length > n ? s[..n] + "…" : s;
 
-    // ---------- Windows Credential Manager P/Invoke ----------
+    // ---------- OAuth client 파일 ----------
 
-    private sealed record CredentialPayload(string? AccessToken, string? RefreshToken);
-    private sealed record OAuthClientConfig(string ClientId, string ClientSecret);
-
-    private static OAuthClientConfig? ReadClientConfig()
+    private static AntigravityOAuthClient? ReadClientConfig()
     {
-        if (!File.Exists(ClientConfigPath)) return null;
-        var json = File.ReadAllText(ClientConfigPath);
-        using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
-        var id  = root.TryGetProperty("client_id",     out var a) ? a.GetString() : null;
-        var sec = root.TryGetProperty("client_secret", out var b) ? b.GetString() : null;
-        if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(sec)) return null;
-        return new OAuthClientConfig(id, sec);
+        try
+        {
+            if (!File.Exists(ClientConfigPath)) return null;
+
+            using var fs = new FileStream(ClientConfigPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var doc = JsonDocument.Parse(fs);
+            var root = doc.RootElement;
+
+            var id = root.TryGetProperty("client_id", out var a) ? a.GetString() : null;
+            var secret = root.TryGetProperty("client_secret", out var b) ? b.GetString() : null;
+            if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(secret)) return null;
+
+            return new AntigravityOAuthClient(id, secret);
+        }
+        catch
+        {
+            return null;
+        }
     }
+
+    private static void TrySaveClientConfig(AntigravityOAuthClient client)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(ClientConfigPath);
+            if (string.IsNullOrEmpty(dir)) return;
+            Directory.CreateDirectory(dir);
+
+            var json = JsonSerializer.Serialize(new Dictionary<string, string>
+            {
+                ["client_id"] = client.ClientId,
+                ["client_secret"] = client.ClientSecret,
+            }, new JsonSerializerOptions { WriteIndented = true });
+
+            // 쓰다 만 파일이 남지 않도록 임시 파일에 쓴 뒤 옮긴다.
+            var temp = ClientConfigPath + ".tmp";
+            File.WriteAllText(temp, json);
+            File.Move(temp, ClientConfigPath, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning($"[AntigravityUsageMonitor] client config save failed: {ex.Message}");
+        }
+    }
+
+    // ---------- Windows 자격 증명 관리자 ----------
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     private struct CREDENTIAL
@@ -298,27 +449,50 @@ public sealed class AntigravityUsageMonitor : IDisposable
 
     private const uint CRED_TYPE_GENERIC = 1;
 
-    private static CredentialPayload? ReadCredStore()
+    internal static StoredCredential? ReadCredStore()
     {
-        IntPtr ptr;
-        if (!CredRead(CredentialTarget, CRED_TYPE_GENERIC, 0, out ptr))
+        if (!CredRead(CredentialTarget, CRED_TYPE_GENERIC, 0, out IntPtr ptr))
             return null;          // ERROR_NOT_FOUND 등 — Antigravity 미설치/미로그인
+
         try
         {
             var c = Marshal.PtrToStructure<CREDENTIAL>(ptr);
             if (c.CredentialBlobSize == 0 || c.CredentialBlob == IntPtr.Zero) return null;
+
             var buf = new byte[c.CredentialBlobSize];
             Marshal.Copy(c.CredentialBlob, buf, 0, buf.Length);
-            var json = Encoding.UTF8.GetString(buf).TrimEnd('\0');
-            using var doc = JsonDocument.Parse(json);
-            var token = doc.RootElement.GetProperty("token");
-            return new CredentialPayload(
-                token.TryGetProperty("access_token", out var a) ? a.GetString() : null,
-                token.TryGetProperty("refresh_token", out var r) ? r.GetString() : null);
+            return ParseCredentialBlob(Encoding.UTF8.GetString(buf).TrimEnd('\0'));
         }
         finally
         {
             CredFree(ptr);
         }
     }
+
+    /// <summary>
+    /// 자격 증명 blob 은 <c>{"token":{"access_token":…,"refresh_token":…,"expiry":…},"id_token":…}</c> 형태다.
+    /// id_token 은 계정 신원이라 읽지 않는다.
+    /// </summary>
+    internal static StoredCredential? ParseCredentialBlob(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("token", out var token) || token.ValueKind != JsonValueKind.Object)
+            return null;
+
+        var access = token.TryGetProperty("access_token", out var a) ? a.GetString() : null;
+        var refresh = token.TryGetProperty("refresh_token", out var r) ? r.GetString() : null;
+
+        DateTimeOffset? expiry = null;
+        if (token.TryGetProperty("expiry", out var e) && e.ValueKind == JsonValueKind.String &&
+            DateTimeOffset.TryParse(e.GetString(), null,
+                System.Globalization.DateTimeStyles.AssumeUniversal, out var parsed))
+        {
+            expiry = parsed;
+        }
+
+        return new StoredCredential(access, refresh, expiry);
+    }
 }
+
+/// <summary>자격 증명 관리자에 Antigravity 가 저장해 둔 토큰 묶음.</summary>
+internal sealed record StoredCredential(string? AccessToken, string? RefreshToken, DateTimeOffset? ExpiresAt);

--- a/ClaudeUsageTray/Services/LocalizationService.cs
+++ b/ClaudeUsageTray/Services/LocalizationService.cs
@@ -333,6 +333,79 @@ public static class Loc
         _ => $"{count} session(s) today"
     };
 
+    /// <summary>
+    /// Antigravity 할당량 한 칸의 이름. 서버는 이 값을 영어로만 내려주므로 아는 버킷은 직접 번역한다.
+    /// 모르는 버킷이면 null 을 돌려주고, 화면은 서버가 준 문구를 그대로 쓴다.
+    /// </summary>
+    public static string? AntigravityBucketLabel(string bucketId, string window)
+    {
+        var group = AntigravityGroupName(bucketId);
+        var span = AntigravityWindowName(window);
+        if (group is null || span is null) return null;
+        return $"{group} · {span}";
+    }
+
+    /// <summary>버킷 식별자 앞부분이 모델 그룹을 가리킨다 (gemini-weekly, 3p-5h).</summary>
+    private static string? AntigravityGroupName(string bucketId)
+    {
+        if (bucketId.StartsWith("gemini", StringComparison.OrdinalIgnoreCase))
+        {
+            return Lang switch
+            {
+                "ko" => "Gemini 모델",
+                "zh" => "Gemini 模型",
+                "ja" => "Gemini モデル",
+                _ => "Gemini Models"
+            };
+        }
+
+        // Google 이 자사 모델과 구분해 부르는 이름(third-party) 이 3p 다.
+        if (bucketId.StartsWith("3p", StringComparison.OrdinalIgnoreCase))
+        {
+            return Lang switch
+            {
+                "ko" => "Claude · GPT 모델",
+                "zh" => "Claude 和 GPT 模型",
+                "ja" => "Claude・GPT モデル",
+                _ => "Claude and GPT models"
+            };
+        }
+
+        return null;
+    }
+
+    private static string? AntigravityWindowName(string window) => window switch
+    {
+        "weekly" => Lang switch
+        {
+            "ko" => "주간 잔여량",
+            "zh" => "每周剩余",
+            "ja" => "週間残量",
+            _ => "Weekly Limit Remaining"
+        },
+        "5h" => Lang switch
+        {
+            "ko" => "5시간 잔여량",
+            "zh" => "5 小时剩余",
+            "ja" => "5時間残量",
+            _ => "Five Hour Limit Remaining"
+        },
+        _ => null
+    };
+
+    /// <summary>사용량 행 오른쪽에 붙는 소진율 표기.</summary>
+    public static string PercentUsed(double fraction)
+    {
+        var percent = $"{fraction * 100:0}%";
+        return Lang switch
+        {
+            "ko" => $"{percent} 사용",
+            "zh" => $"已用 {percent}",
+            "ja" => $"{percent} 使用",
+            _ => $"{percent} used"
+        };
+    }
+
     public static string ResetsIn(string time) => Lang switch
     {
         "ko" => $" · {time} 후 초기화",

--- a/ClaudeUsageTray/ViewModels/AntigravityViewModel.cs
+++ b/ClaudeUsageTray/ViewModels/AntigravityViewModel.cs
@@ -21,6 +21,12 @@ public partial class AntigravityViewModel : ObservableObject
     /// <summary>마지막 조회 결과 원본 — MainViewModel 이 다중 PC 동기화에 쓴다.</summary>
     public AntigravitySnapshot LastSnapshot { get; private set; } = new();
 
+    // 화면에 올린 마지막 입력. 언어가 바뀌면 이 값으로 행을 다시 만든다
+    // (LastSnapshot 과 별개다 — 다른 PC 에서 받은 값을 표시 중일 수 있다).
+    private IReadOnlyList<AntigravityModelQuota> _appliedQuota = System.Array.Empty<AntigravityModelQuota>();
+    private string? _appliedTierName;
+    private string? _appliedPaidTierName;
+
     public AntigravityViewModel(AntigravityUsageMonitor monitor)
     {
         _monitor = monitor;
@@ -81,6 +87,10 @@ public partial class AntigravityViewModel : ObservableObject
     /// </summary>
     public void ApplyQuota(IReadOnlyList<AntigravityModelQuota> models, string? tierName, string? paidTierName)
     {
+        _appliedQuota = models;
+        _appliedTierName = tierName;
+        _appliedPaidTierName = paidTierName;
+
         HasData = true;
         HasError = false;
         ErrorMessage = "";
@@ -116,6 +126,16 @@ public partial class AntigravityViewModel : ObservableObject
         // 창마다 한도가 따로 걸리므로 평균은 가장 급한 제약을 가린다 (주간 90% + 5시간 0% → 45%).
         // 트레이 게이지에는 가장 많이 쓴 창을 올린다.
         Percent = worstUsed;
+    }
+
+    /// <summary>
+    /// 언어를 바꿨을 때 이미 만들어 둔 행을 다시 만든다.
+    /// 행의 문구는 만들 때 한 번 정해지므로, 다시 만들지 않으면 다음 조회까지 이전 언어로 남는다.
+    /// </summary>
+    public void RefreshLocalizedLabels()
+    {
+        if (!HasData || _appliedQuota.Count == 0) return;
+        ApplyQuota(_appliedQuota, _appliedTierName, _appliedPaidTierName);
     }
 
     /// <summary>

--- a/ClaudeUsageTray/ViewModels/AntigravityViewModel.cs
+++ b/ClaudeUsageTray/ViewModels/AntigravityViewModel.cs
@@ -104,9 +104,9 @@ public partial class AntigravityViewModel : ObservableObject
             rows.Add(new AntigravityModelRow
             {
                 ModelId = m.ModelId,
-                DisplayName = string.IsNullOrWhiteSpace(m.DisplayName) ? FormatModelName(m.ModelId) : m.DisplayName,
+                DisplayName = ResolveDisplayName(m),
                 UsagePercent = used,
-                UsageLabel = $"{used * 100:0}% used",
+                UsageLabel = Loc.PercentUsed(used),
                 ResetAtLabel = FormatResetLabel(m.ResetTime),
             });
         }
@@ -116,6 +116,20 @@ public partial class AntigravityViewModel : ObservableObject
         // 창마다 한도가 따로 걸리므로 평균은 가장 급한 제약을 가린다 (주간 90% + 5시간 0% → 45%).
         // 트레이 게이지에는 가장 많이 쓴 창을 올린다.
         Percent = worstUsed;
+    }
+
+    /// <summary>
+    /// 아는 버킷은 앱 언어로 부르고, 모르는 버킷만 서버가 준 영어 문구를 쓴다.
+    /// 표시 이름을 함께 보내지 않던 버전이 동기화한 값은 식별자를 다듬어 쓴다.
+    /// </summary>
+    internal static string ResolveDisplayName(AntigravityModelQuota quota)
+    {
+        var localized = Loc.AntigravityBucketLabel(quota.ModelId, quota.TokenType);
+        if (localized is not null) return localized;
+
+        return string.IsNullOrWhiteSpace(quota.DisplayName)
+            ? FormatModelName(quota.ModelId)
+            : quota.DisplayName;
     }
 
     internal static string FormatModelName(string modelId)

--- a/ClaudeUsageTray/ViewModels/AntigravityViewModel.cs
+++ b/ClaudeUsageTray/ViewModels/AntigravityViewModel.cs
@@ -65,11 +65,7 @@ public partial class AntigravityViewModel : ObservableObject
             if (!snap.HasData)
             {
                 HasData = false;
-                bool isInformational =
-                    string.Equals(snap.ErrorMessage, "Antigravity not signed in", StringComparison.Ordinal)
-                    || string.Equals(snap.ErrorMessage, "no refresh_token in credstore", StringComparison.Ordinal)
-                    || string.Equals(snap.ErrorMessage, "Antigravity OAuth client not configured", StringComparison.Ordinal);
-                HasError = !isInformational && !string.IsNullOrEmpty(snap.ErrorMessage);
+                HasError = !snap.IsInformational && !string.IsNullOrEmpty(snap.ErrorMessage);
                 ErrorMessage = HasError ? (snap.ErrorMessage ?? "") : "";
                 Models = System.Array.Empty<AntigravityModelRow>();
                 return;
@@ -91,8 +87,7 @@ public partial class AntigravityViewModel : ObservableObject
         TierName = tierName ?? "";
         PaidTierName = paidTierName ?? "";
 
-        double totalUsed = 0;
-        int modelCount = 0;
+        double worstUsed = 0;
         var rows = new List<AntigravityModelRow>(models.Count);
         foreach (var m in models)
         {
@@ -102,15 +97,14 @@ public partial class AntigravityViewModel : ObservableObject
                 continue;
 
             double used = Math.Clamp(1.0 - m.RemainingFraction, 0.0, 1.0);
-            totalUsed += used;
-            modelCount++;
+            if (used > worstUsed) worstUsed = used;
 
-            if (used <= 0) continue;
-
+            // 아직 쓰지 않은 창도 남겨 둔다. Antigravity 화면과 같은 네 칸(그룹 × 주간·5시간)이
+            // 항상 보여야 지금 무엇이 얼마나 남았는지 읽을 수 있다.
             rows.Add(new AntigravityModelRow
             {
                 ModelId = m.ModelId,
-                DisplayName = FormatModelName(m.ModelId),
+                DisplayName = string.IsNullOrWhiteSpace(m.DisplayName) ? FormatModelName(m.ModelId) : m.DisplayName,
                 UsagePercent = used,
                 UsageLabel = $"{used * 100:0}% used",
                 ResetAtLabel = FormatResetLabel(m.ResetTime),
@@ -119,7 +113,9 @@ public partial class AntigravityViewModel : ObservableObject
         rows.Sort((a, b) => b.UsagePercent.CompareTo(a.UsagePercent));
         Models = rows;
 
-        Percent = modelCount > 0 ? totalUsed / modelCount : 0.0;
+        // 창마다 한도가 따로 걸리므로 평균은 가장 급한 제약을 가린다 (주간 90% + 5시간 0% → 45%).
+        // 트레이 게이지에는 가장 많이 쓴 창을 올린다.
+        Percent = worstUsed;
     }
 
     internal static string FormatModelName(string modelId)

--- a/ClaudeUsageTray/ViewModels/MainViewModel.cs
+++ b/ClaudeUsageTray/ViewModels/MainViewModel.cs
@@ -2755,6 +2755,9 @@ namespace ClaudeUsageTray.ViewModels;
         System.Windows.Application.Current?.Dispatcher.Invoke(() =>
         {
             OpenCodeVm.RefreshLocalizedLabels();
+            AntigravityVm.RefreshLocalizedLabels();
+            // 행 객체가 새로 만들어지므로 미러 프로퍼티도 다시 가리켜야 화면이 바뀐다.
+            AntigravityModels = AntigravityVm.Models;
             OnPropertyChanged(string.Empty);
         });
     }

--- a/ClaudeUsageTray/ViewModels/MainViewModel.cs
+++ b/ClaudeUsageTray/ViewModels/MainViewModel.cs
@@ -2854,6 +2854,7 @@ namespace ClaudeUsageTray.ViewModels;
                 ModelId = model.ModelId,
                 RemainingFraction = model.RemainingFraction,
                 ResetAt = model.ResetTime,
+                DisplayName = model.DisplayName,
             })],
         };
     }
@@ -2864,6 +2865,7 @@ namespace ClaudeUsageTray.ViewModels;
             ModelId = model.ModelId,
             RemainingFraction = model.RemainingFraction,
             ResetTime = model.ResetAt,
+            DisplayName = model.DisplayName,
         })];
 }
 

--- a/ClaudeUsageTray/ViewModels/MainViewModel.cs
+++ b/ClaudeUsageTray/ViewModels/MainViewModel.cs
@@ -2855,6 +2855,7 @@ namespace ClaudeUsageTray.ViewModels;
                 RemainingFraction = model.RemainingFraction,
                 ResetAt = model.ResetTime,
                 DisplayName = model.DisplayName,
+                Window = model.TokenType,
             })],
         };
     }
@@ -2866,6 +2867,7 @@ namespace ClaudeUsageTray.ViewModels;
             RemainingFraction = model.RemainingFraction,
             ResetTime = model.ResetAt,
             DisplayName = model.DisplayName,
+            TokenType = model.Window,
         })];
 }
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Windows 시스템 트레이에서 Claude, Codex(ChatGPT), Gemini CLI, OpenCode A
 - **변경 이력**: [CHANGELOG.md](CHANGELOG.md)
 
 ## 이슈
+- `버그` Antigravity 게이지가 수동 설정 없이는 뜨지 않고, 뜨더라도 앱 화면과 다른 값을 보여줌 (2026-08-11): 조회 첫 단계에서 사용자가 직접 만들어야 하는 OAuth client 파일을 요구해, 그 파일이 없는 대부분의 PC 에서 섹션이 조용히 사라졌다(파일을 만들려면 실행 중인 `language_server.exe` 의 400MB 메모리 덤프가 필요했다). 자격 증명 관리자에는 refresh token 뿐 아니라 **유효한 access token 도 함께** 저장돼 있어 이 단계 자체가 불필요했다. 저장된 토큰을 먼저 쓰고, 만료됐을 때만 설치된 바이너리에서 client 값을 찾아 갱신하도록 바꿔 사전 설정을 없앴다. 또한 호출 대상을 `retrieveUserQuota` 에서 `retrieveUserQuotaSummary` 로 바꿔 Antigravity 앱의 `Models & Usage` 화면과 같은 게이지(그룹별 주간·5시간)를 표시하고, 아직 쓰지 않은 창도 숨기지 않는다. 트레이 대표값은 평균 대신 가장 소진된 창을 쓴다. #137
 - `버그` PC 재부팅 뒤 OpenCode 로그인이 풀린 것처럼 보임 (2026-08-11): 부팅 직후 네트워크가 준비되기 전의 탐색 실패를 로그아웃과 구분하지 않아, 세션이 멀쩡한데도 `OpenCode 로그인` 버튼이 뜨고 30분 동안 재시도하지 않았다. 서버가 로그인 페이지로 되돌린 경우에만 로그인 해제로 판정하고, 확인 자체를 못 한 경우에는 버튼 대신 재시도 안내를 표시하며 1분부터 시작하는 짧은 간격으로 다시 확인한다. 조용히 넘어가던 탐색 실패의 이유도 기록한다. #130
 - `개선` 동기화 값만 쓰는 PC에서 할당량 시효가 지나면 로그인 버튼이 떠 로그인이 풀린 것처럼 보임 (2026-08-10): 다른 PC가 관측한 OpenCode 공식 할당량이 최대 40분의 유효시간을 넘기면 게이지가 사라지고 `OpenCode 로그인` 버튼이 노출돼, 로그인한 적도 없는 PC에서 동기화가 끊긴 것으로 오해했다. 오늘 다른 PC의 관측 이력이 있으면 버튼 대신 마지막 관측 시각과 기기명을 안내하고, 관측 이력이 없을 때만 로그인 버튼을 남긴다. #134
 - `버그` 다른 PC에서만 쓰는 공급자 섹션이 표시되지 않음 (2026-08-10): 동기화 합계를 화면 값으로 쓸지 판단할 때 "사용량이 있는 기기"가 2대 이상일 것을 요구해, 이 PC에서 한 번도 쓰지 않은 공급자(예: OpenCode)는 기기 수가 1이 되어 다른 PC의 합계가 통째로 버려졌다. `데이터 없는 공급자 자동 숨김`과 맞물려 섹션 자체가 사라졌다. 합계에 데이터가 있으면 기기 수와 무관하게 반영한다. #133
@@ -143,23 +144,14 @@ Windows 시스템 트레이에서 Claude, Codex(ChatGPT), Gemini CLI, OpenCode A
 - **Go 할당량**: 앱 전용 로그인 창으로 연결하면 공식 콘솔의 롤링/주간/월간 사용률과 초기화 시각을 표시합니다. 기존 브라우저 로그인 정보는 읽지 않습니다.
 
 ### 5. Antigravity (Google Gemini Code Assist IDE) — v1.31.0+
-- **인증**: Windows Credential Manager 의 `gemini:antigravity` 항목(Antigravity 가 로그인 후 자동 저장하는 OAuth refresh token)을 재사용.
-- **할당량**: `daily-cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota` 를 1시간 주기로 호출하여 모델별 잔여 비율 + 다음 리셋 시각을 받음.
-- **표시**: Gemini 2.5/3.x 계열, Claude Sonnet/Opus 4.6 (Thinking), GPT-OSS 120B 등 사용자 plan 에 포함된 모델 전부 progress bar 로 렌더.
-- **사전 설정 필요**: 비공식 API 라 OAuth client 자격 증명을 사용자가 직접 추출해 다음 경로에 두어야 합니다 — 파일이 없으면 섹션이 자동으로 숨겨집니다.
-
-  ```
-  %APPDATA%\ClaudeUsageTray\antigravity-oauth-client.json
-  ```
-
-  ```json
-  {
-    "client_id": "<Antigravity's OAuth client ID>",
-    "client_secret": "<Antigravity's OAuth client secret>"
-  }
-  ```
-
-  값 추출 방법은 [docs/antigravity-setup.md](docs/antigravity-setup.md) 참고. Antigravity 2.0 마이너 업데이트로 값이 바뀌면 파일을 다시 채워야 합니다.
+- **인증**: Windows 자격 증명 관리자의 `gemini:antigravity` 항목을 재사용합니다. Antigravity 에 로그인해 두었다면 **따로 설정할 것이 없습니다.**
+  - 저장된 access token 이 살아 있으면 그대로 씁니다.
+  - 만료되었으면 refresh token 으로 갱신하며, 이때 필요한 OAuth client 값은 설치된 `language_server.exe` 에서 자동으로 찾습니다(약 2초, 한 번 성공하면 저장해 두고 재사용).
+- **할당량**: `daily-cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary` 를 호출해 Antigravity 앱의 `Models & Usage` 화면과 **같은 게이지**를 받습니다 — `Gemini Models` 와 `Claude and GPT models` 각각의 주간·5시간 잔여량 + 다음 초기화 시각.
+- **표시**: 네 칸(그룹 × 주간·5시간)을 progress bar 로 렌더하고, 트레이 게이지에는 그중 **가장 많이 소진된 창**을 올립니다. 창마다 한도가 따로 걸리므로 평균을 쓰면 급한 제약이 가려집니다.
+- **Antigravity 를 실행하지 않아도 조회됩니다.** 앱의 로컬 서버가 아니라 Google 백엔드를 직접 호출하기 때문입니다.
+- 로그인하지 않았거나 세션이 만료되어 갱신에 실패하면 오류를 띄우지 않고 섹션만 숨깁니다. Antigravity 를 한 번 실행하면 다시 표시됩니다.
+- 비공식 API 라 클라이언트 업데이트로 규칙이 바뀔 수 있습니다. 자동 탐색이 실패하는 경우의 수동 지정 방법은 [docs/antigravity-setup.md](docs/antigravity-setup.md) 를 참고하세요.
 
 ---
 

--- a/docs/antigravity-setup.md
+++ b/docs/antigravity-setup.md
@@ -1,53 +1,41 @@
 # Antigravity 통합 셋업
 
-Antigravity (Google Gemini Code Assist IDE) 의 모델별 quota 패널을 트레이에 표시하려면 OAuth client 자격 증명이 필요합니다. Antigravity 의 비공식 API 를 호출하기 위함이며, 값은 사용자 PC 의 Antigravity 바이너리/메모리에서 추출합니다.
+> **보통은 아무 설정도 필요 없습니다.** Antigravity 에 로그인만 되어 있으면 트레이 앱이 알아서 사용량을 읽습니다.
+> 이 문서는 자동 탐색이 실패했을 때 직접 값을 지정하는 방법을 다룹니다.
 
-## 어떤 값이 필요한가
+## 어떻게 동작하나
 
-- **client_id**: `<숫자>-<영숫자>.apps.googleusercontent.com` 형태
-- **client_secret**: `GOCSPX-` 로 시작하는 문자열 (35자 안팎)
+트레이 앱은 Antigravity 를 실행하지 않아도 사용량을 읽습니다. 앱의 로컬 서버가 아니라 Google 백엔드를 직접 호출하기 때문입니다.
 
-## 추출 방법
+1. **토큰 읽기** — Windows 자격 증명 관리자의 `gemini:antigravity` 항목에서 Antigravity 가 저장해 둔 토큰을 읽습니다.
+2. **그대로 사용** — 저장된 access token 이 아직 유효하면(발급 후 약 1시간) 그대로 씁니다. 이 경로에는 OAuth client 자격 증명이 **필요 없습니다.**
+3. **만료 시 갱신** — 토큰이 만료됐으면 refresh token 으로 갱신합니다. 이때만 client_id/secret 이 필요하며, 설치된 `language_server.exe` 에서 자동으로 찾습니다(약 2초). 통한 조합은 `%APPDATA%\ClaudeUsageTray\antigravity-oauth-client.json` 에 저장해 다음부터는 다시 훑지 않습니다.
+4. **조회** — `v1internal:retrieveUserQuotaSummary` 로 그룹별(Gemini / Claude·GPT) 주간·5시간 잔여량을 받습니다. Antigravity 앱의 `Models & Usage` 화면이 보여주는 값과 같습니다.
 
-### 옵션 A — 메모리 추출 (Antigravity 실행 중일 때만, 권장)
+로그인하지 않았거나, 세션이 만료됐는데 갱신에 실패하면 오류 대신 섹션이 숨겨집니다. **Antigravity 를 한 번 실행하면** 앱이 토큰을 새로 발급해 두므로 다시 표시됩니다. 대개 이것으로 해결됩니다.
 
-Antigravity 가 실행 중인 상태에서 `language_server.exe` 프로세스의 메모리에 client_id/secret 이 평문으로 보관됩니다. PowerShell 로 추출:
+## 자동 탐색이 실패할 때
+
+Antigravity 가 설치 위치를 바꾸거나 자격 증명 형식을 바꾸면 자동 탐색이 실패할 수 있습니다. 그때는 값을 직접 넣습니다.
+
+### 1. 값 추출
+
+설치된 바이너리에서 뽑습니다. Antigravity 를 실행 중이 아니어도 됩니다.
 
 ```powershell
-# 1. language_server.exe PID 확인
-$pid = (Get-CimInstance Win32_Process -Filter "Name='language_server.exe'").ProcessId
-
-# 2. 메모리 dump (사용자 권한이면 가능, 사이즈 약 400MB)
-Add-Type -TypeDefinition @'
-using System; using System.Runtime.InteropServices; using System.IO; using System.Diagnostics;
-public static class MD {
-  [DllImport("Dbghelp.dll")]
-  public static extern bool MiniDumpWriteDump(IntPtr h, uint pid, IntPtr file, uint t, IntPtr e, IntPtr u, IntPtr c);
-  public static void Dump(int pid, string path) {
-    var p = Process.GetProcessById(pid);
-    using (var fs = new FileStream(path, FileMode.Create))
-      MiniDumpWriteDump(p.Handle, (uint)pid, fs.SafeFileHandle.DangerousGetHandle(), 2, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
-  }
-}
-'@ -Language CSharp
-[MD]::Dump($pid, "$env:TEMP\ls.dmp")
-
-# 3. dump 에서 client_id 와 secret 패턴 추출
-$bytes = [IO.File]::ReadAllBytes("$env:TEMP\ls.dmp")
-$text = -join ($bytes | ForEach-Object { if ($_ -ge 32 -and $_ -lt 127) { [char]$_ } else { ' ' } })
-$ids     = ([regex]::Matches($text, '[0-9]{8,15}-[a-z0-9]{20,40}\.apps\.googleusercontent\.com')).Value | Sort-Object -Unique
-$secrets = ([regex]::Matches($text, 'GOCSPX-[A-Za-z0-9_-]{20,40}')).Value | Sort-Object -Unique
-$ids
-$secrets
+$exe = "$env:LOCALAPPDATA\Programs\antigravity\resources\bin\language_server.exe"
+$bytes = [IO.File]::ReadAllBytes($exe)
+$text = [Text.Encoding]::ASCII.GetString($bytes)
+([regex]::Matches($text, '[0-9]{6,}-[a-z0-9]{15,}\.apps\.googleusercontent\.com')).Value | Sort-Object -Unique
+([regex]::Matches($text, 'GOCSPX-[A-Za-z0-9_-]{28}')).Value | Sort-Object -Unique
 ```
 
-### 옵션 B — 정적 추출 (`language_server.exe` 바이너리)
+- **client_id**: `<숫자>-<영숫자>.apps.googleusercontent.com`
+- **client_secret**: `GOCSPX-` + 28자 (총 35자). 길이가 35자가 아니면 경계를 잘못 잡은 것입니다.
 
-Antigravity 가 실행 중이지 않을 때도 동일한 client_id 가 바이너리에 박혀있습니다. 같은 PowerShell regex 를 `C:\Users\<USER>\AppData\Local\Programs\Antigravity\resources\bin\language_server.exe` 에 돌리면 됩니다 (130MB 바이너리라 시간 좀 걸림).
+각각 여러 개가 나올 수 있습니다. 바이너리에 짝 정보가 없으므로 어느 조합이 맞는지는 시도해 봐야 알 수 있습니다(앱은 자동으로 순서대로 시도합니다).
 
-## 파일 작성
-
-추출한 값을 다음 경로에 저장 (디렉터리는 자동 생성):
+### 2. 파일 작성
 
 ```
 %APPDATA%\ClaudeUsageTray\antigravity-oauth-client.json
@@ -55,18 +43,23 @@ Antigravity 가 실행 중이지 않을 때도 동일한 client_id 가 바이너
 
 ```json
 {
-  "client_id": "1071006060591-...apps.googleusercontent.com",
-  "client_secret": "GOCSPX-..."
+  "client_id": "<숫자>-<영숫자>.apps.googleusercontent.com",
+  "client_secret": "GOCSPX-<28자>"
 }
 ```
 
-## 짝 맞는지 검증
+### 3. 확인
 
-저장 후 트레이 앱 새로고침 → "Antigravity" 섹션이 사용자의 plan + 모델별 quota 와 함께 뜨면 성공. 아무 일도 안 나면:
+트레이 앱 새로고침 → `Antigravity` 섹션에 플랜과 네 개의 게이지가 뜨면 성공입니다.
 
-- `gemini:antigravity` 라는 항목이 Windows Credential Manager 에 있는지 (`cmdkey /list`) 확인 — 없으면 Antigravity 로그인부터.
-- secret 길이가 35자가 안 되면 boundary 잘못 잡힌 것 (인접한 다른 secret 의 prefix 가 섞임). 가능한 다른 후보로 재시도.
+아무 일도 없다면 자격 증명 관리자에 항목이 있는지부터 확인하세요.
 
-## 왜 코드에 박지 않나
+```powershell
+cmdkey /list:gemini:antigravity
+```
 
-Google 의 secret-scanning 정책상 public repo 에 client_secret 노출 시 자동 revoke 가능성이 있고, Antigravity 의 마이너 업데이트로 client 가 회전될 수도 있어 사용자 PC 단위로 분리해 관리합니다.
+없으면 Antigravity 로그인이 먼저입니다.
+
+## 왜 secret 을 코드에 박지 않나
+
+Google 의 secret-scanning 정책상 공개 저장소에 client_secret 이 노출되면 자동으로 폐기될 수 있고, Antigravity 업데이트로 값이 바뀔 수도 있습니다. 그래서 저장소에 넣지 않고 각 PC 에 설치된 바이너리에서 읽습니다.

--- a/test-antigravity/Program.cs
+++ b/test-antigravity/Program.cs
@@ -1,6 +1,9 @@
 // One-shot smoke test for AntigravityUsageMonitor.
 // Run: dotnet run --project test-antigravity from ClaudeUsageTray/.
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
 using System.Threading.Tasks;
 using ClaudeUsageTray.Services;
 
@@ -12,13 +15,65 @@ internal static class Program
         var snap = await mon.GetSnapshotAsync();
         Console.WriteLine($"HasData          = {snap.HasData}");
         Console.WriteLine($"ErrorMessage     = {snap.ErrorMessage}");
+        Console.WriteLine($"IsInformational  = {snap.IsInformational}");
         Console.WriteLine($"TierName         = {snap.TierName}");
         Console.WriteLine($"PaidTierName     = {snap.PaidTierName}");
-        Console.WriteLine($"Models.Count     = {snap.Models.Count}");
+        Console.WriteLine($"Buckets.Count    = {snap.Models.Count}");
         foreach (var m in snap.Models)
         {
-            Console.WriteLine($"  - {m.ModelId,-24} type={m.TokenType,-10} remaining={m.RemainingFraction,6:0.000}  reset={m.ResetTime:o}");
+            Console.WriteLine($"  - {m.DisplayName,-38} {m.RemainingFraction,6:P0} left  window={m.TokenType,-7} id={m.ModelId,-12} reset={m.ResetTime:u}");
         }
+        await VerifyRefreshPathAsync();
         return snap.HasData ? 0 : 1;
+    }
+
+    /// <summary>
+    /// 저장된 access_token 이 만료됐을 때 타는 경로를 미리 확인한다.
+    /// 설치된 바이너리에서 찾아낸 client 자격 증명으로 실제 갱신이 되는지까지 본다.
+    /// </summary>
+    private static async Task VerifyRefreshPathAsync()
+    {
+        Console.WriteLine();
+        Console.WriteLine("-- refresh path --");
+
+        var path = AntigravityOAuthClientLocator.FindLanguageServerPath();
+        Console.WriteLine($"language_server  = {path ?? "(not found)"}");
+        if (path is null) return;
+
+        var started = DateTimeOffset.UtcNow;
+        IReadOnlyList<AntigravityOAuthClient> candidates;
+        using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+        {
+            candidates = AntigravityOAuthClientLocator.ScanCandidates(fs);
+        }
+        Console.WriteLine($"scan             = {(DateTimeOffset.UtcNow - started).TotalSeconds:0.0}s, {candidates.Count} candidate pair(s)");
+        foreach (var c in candidates)
+        {
+            Console.WriteLine($"  - {c.ClientId}  secret={c.ClientSecret[..14]}…({c.ClientSecret.Length})");
+        }
+        if (candidates.Count == 0) return;
+
+        var refreshToken = AntigravityUsageMonitor.ReadCredStore()?.RefreshToken;
+        if (string.IsNullOrEmpty(refreshToken)) { Console.WriteLine("refresh_token    = (unavailable)"); return; }
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+        foreach (var c in candidates)
+        {
+            var form = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["client_id"] = c.ClientId,
+                ["client_secret"] = c.ClientSecret,
+                ["grant_type"] = "refresh_token",
+                ["refresh_token"] = refreshToken,
+            });
+            using var resp = await http.PostAsync("https://oauth2.googleapis.com/token", form);
+            Console.WriteLine($"  try {c.ClientId[..20]}… -> HTTP {(int)resp.StatusCode}");
+            if (resp.IsSuccessStatusCode)
+            {
+                Console.WriteLine("  => refresh OK (앱이 꺼진 채 토큰이 만료돼도 갱신 가능)");
+                return;
+            }
+        }
+        Console.WriteLine("  => 어떤 조합으로도 갱신하지 못함");
     }
 }

--- a/test-antigravity/test-antigravity.csproj
+++ b/test-antigravity/test-antigravity.csproj
@@ -9,7 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Only compile the bits the monitor needs — avoid pulling WPF/WindowsForms from the main proj. -->
-    <Compile Include="..\ClaudeUsageTray\Services\AntigravityUsageMonitor.cs" Link="AntigravityUsageMonitor.cs" />
-    <Compile Include="..\ClaudeUsageTray\Models\AntigravityUsage.cs"          Link="AntigravityUsage.cs" />
+    <Compile Include="..\ClaudeUsageTray\Services\AntigravityUsageMonitor.cs"         Link="AntigravityUsageMonitor.cs" />
+    <Compile Include="..\ClaudeUsageTray\Services\AntigravityOAuthClientLocator.cs"   Link="AntigravityOAuthClientLocator.cs" />
+    <Compile Include="..\ClaudeUsageTray\Services\AppConstants.cs"                    Link="AppConstants.cs" />
+    <Compile Include="..\ClaudeUsageTray\Models\AntigravityUsage.cs"                  Link="AntigravityUsage.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## 무엇이 문제였나

Antigravity 통합(v1.31.0)이 **대부분의 PC에서 아무것도 표시하지 않았습니다.**

조회 첫 단계에서 사용자가 직접 만들어야 하는 OAuth client 파일(`%APPDATA%\ClaudeUsageTray\antigravity-oauth-client.json`)을 요구하고, 없으면 즉시 폴백해 섹션을 숨겼습니다. 그 파일을 만들려면 실행 중인 `language_server.exe`의 **400MB 메모리 덤프**를 떠서 값을 정규식으로 뽑아내야 했습니다. 개발 PC에도 이 파일이 없어 기능이 죽어 있었습니다.

**그런데 이 단계는 애초에 불필요했습니다.** Windows 자격 증명 관리자의 `gemini:antigravity` 항목에는 refresh token뿐 아니라 **아직 유효한 access token과 만료 시각이 함께** 저장돼 있습니다.

또한 표시되더라도 Antigravity 앱의 `Models & Usage` 화면과 **다른 값**이었습니다. `retrieveUserQuota`는 Gemini 모델별 요청 잔량을 주는데, 화면의 게이지는 `retrieveUserQuotaSummary`가 내는 그룹별 주간·5시간 잔여량입니다.

## 무엇을 바꿨나

**인증 — 사전 설정 제거**
- 저장된 access token이 유효하면 그대로 사용합니다. 이 경로에는 client 자격 증명이 필요 없습니다.
- 만료됐을 때만 refresh하며, client_id/secret은 설치된 `language_server.exe`에서 자동으로 찾습니다. 바이너리에서는 이 값들이 인접 문자열과 경계 없이 붙어 있어 문자 종류로만 자르면 옆 문자열을 먹으므로, Google이 정한 형식(`숫자-해시.apps.googleusercontent.com`, `GOCSPX-` + 28자)을 경계로 씁니다.
- 통한 조합은 저장해 다음부터 다시 훑지 않습니다.

**조회 — 앱 화면과 같은 게이지**
- `retrieveUserQuotaSummary`로 전환. `user-agent`로 클라이언트 형식을 보내지 않으면 403이라 함께 맞췄습니다.
- 응답의 `groups[] → buckets[]`를 펴서 그룹명과 버킷명을 합친 표시 이름을 만듭니다 (`Gemini Models · Weekly Limit Remaining`).

**표시**
- 사용률 0%인 창도 남깁니다. 안 쓴 주에 상세가 비어 보이던 문제입니다 (Antigravity 앱은 이때도 100% 게이지를 보여줍니다).
- 트레이 대표값을 평균에서 **가장 소진된 창**으로 바꿨습니다. 창마다 한도가 따로 걸려 평균은 급한 제약을 가립니다 (주간 90% + 5시간 0% → 45%로 표시되던 문제).
- 정보성 실패 판정을 에러 문구 `StringComparison.Ordinal` 비교에서 스냅샷 플래그(`IsInformational`)로 옮겼습니다. 문구를 고치면 조용히 깨지던 구조였습니다.
- 표시 이름을 다중 PC 동기화에도 실어 다른 PC에서 같은 이름이 보이게 했습니다 (없던 버전의 스냅샷은 기존 폴백을 탑니다).

## 검증

이 PC에서 실측했습니다.

- **사전 설정 없이 동작** — 네 칸(`Gemini Models` / `Claude and GPT models` × 주간·5시간)과 `Google AI Pro` 플랜명 확인. 스크린샷의 게이지와 일치합니다.
- **만료 후 갱신 경로** — 바이너리 스캔 2.1초 → 후보 4조합 중 세 번째에서 `HTTP 200`. 앞선 두 조합은 401을 받고 다음 후보로 넘어갑니다.
- **테스트 359개 통과** (신규 25개: 응답 파싱·자격 증명 파싱·스캐너 경계·표시 규칙). 스캐너 테스트에는 청크 경계(4MB)에 걸친 값도 포함했습니다.
- **Release 빌드 경고 0 / 오류 0**, 어셈블리 버전 1.39.0 확인.
- XAML 바인딩 대상 프로퍼티 13개가 산출물에 모두 존재함을 리플렉션으로 확인 (XAML 자체는 변경 없음).

기존 테스트 `Antigravity_AppliesSyncedModelRows_LikeALocalLookup`의 마지막 단정 한 줄을 평균에서 최댓값 기대로 고쳤습니다. 의도적 동작 변경이며 이유를 테스트에 주석으로 남겼습니다.

## 확인 부탁드립니다

팝업 UI는 에이전트가 직접 띄울 수 없어(트레이 전용 + `Show()` 전까지 HWND 없음) **화면 모양은 검증하지 못했습니다.** 데이터·계산·바인딩 경로까지만 확인했으니, 실행 후 Antigravity 섹션의 네 칸이 의도대로 보이는지 봐주세요.

## 남은 갭 (이번 범위 밖)

조사 중 확인된 것들로, 게이지 표시와는 별개입니다. #137에 정리해 두겠습니다.

- `IsAntigravityEnabled`가 설정에 저장되지 않아(로드·저장 양쪽에 없음) 사용자가 끌 수 없음
- 설정 창에 Antigravity 표시 토글 없음
- 트레이 아이콘 툴팁·상태 메뉴·`UpdateOverallStatus()`에 Antigravity가 빠져 있어 `데이터 없는 공급자 자동 숨김`과 트레이 표시 모드 선택에서 제외됨
- 모니터의 실패 문구가 영어 하드코딩 (AGENTS.md 규칙 3)

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
