### PR TITLE
Antigravity 게이지를 Codex·Claude 상세와 같은 모양으로 맞춤

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 모든 주요 변경 사항을 이 파일에 기록합니다.
 [Keep a Changelog](https://keepachangelog.com/ko/1.0.0/) 형식을 따릅니다.
 
+## [1.39.2] - 2026-08-12
+
+<!-- ko -->
+### 변경
+- **Antigravity 게이지가 5시간 → 주간 순으로 고정됩니다** — 사용량이 많은 순으로 세우고 있어서 새로고침할 때마다 네 칸의 자리가 뒤바뀌었고, 5시간·주간이 섞여 나와 Claude·Codex 와 읽는 방식이 달랐습니다. 이제 모델 그룹별로 묶고 그 안에서 짧은 창이 위로 갑니다.
+- **게이지 아래에 `45% 사용 · 잔량 55%` 요약이 추가됐습니다** — Claude·Codex 게이지에만 있던 한 줄입니다.
+- **게이지 툴팁이 페이스 문구로 통일됐습니다** — `시간 50% 경과 · 사용 45% · 5%p 여유` 처럼 Claude·Codex 와 같은 내용을 보여주고, 리셋 절대 시각은 그 아래 줄에 남습니다.
+- **상세 맨 아래에 데이터 출처 안내가 생겼습니다** — 다른 에이전트와 같은 자리입니다. 다른 PC 가 올린 값을 보고 있을 때는 오른쪽에 그 PC 와 관측 시각을 적습니다.
+<!-- /ko -->
+
+<!-- en -->
+### Changed
+- **Antigravity gauges are pinned to 5-hour → weekly order** — They were sorted by usage, so the four rows swapped places on every refresh and the 5-hour and weekly windows came out interleaved, unlike Claude and Codex. Rows are now grouped by model group, shortest window first.
+- **Each gauge carries a `45% used · 55% remaining` summary line** — the single line that previously existed only on the Claude and Codex gauges.
+- **Gauge tooltips now show the same pace text as the other agents** — `Time 50% · Used 45% · 5pp behind`, with the absolute reset stamp on the line below.
+- **The detail ends with a data-source note** — same position as the other agents. When another PC's snapshot is on screen, that device and observation time are shown on the right.
+<!-- /en -->
+
 ## [1.39.1] - 2026-08-12
 
 <!-- ko -->

--- a/ClaudeUsageTray.Tests/ViewModels/AntigravityApplyQuotaTests.cs
+++ b/ClaudeUsageTray.Tests/ViewModels/AntigravityApplyQuotaTests.cs
@@ -21,13 +21,14 @@ public sealed class AntigravityApplyQuotaTests
     private static readonly DateTimeOffset Reset = DateTimeOffset.UtcNow.AddHours(3);
 
     private static AntigravityModelQuota Bucket(string id, double remaining, string displayName = "",
-                                                DateTimeOffset? reset = null) =>
+                                                DateTimeOffset? reset = null, string window = "") =>
         new()
         {
             ModelId = id,
             RemainingFraction = remaining,
             DisplayName = displayName,
             ResetTime = reset ?? Reset,
+            TokenType = window,
         };
 
     private static AntigravityViewModel CreateVm(out AntigravityUsageMonitor monitor)
@@ -77,19 +78,66 @@ public sealed class AntigravityApplyQuotaTests
     }
 
     [Fact]
-    public void ApplyQuota_SortsMostConsumedFirst()
+    public void ApplyQuota_OrdersShortWindowFirst_LikeClaudeAndCodex()
     {
         var vm = CreateVm(out var monitor);
         using (monitor)
         {
+            // 사용량 순으로 세우면 새로고침마다 자리가 바뀐다. 다른 provider 처럼 창 길이 순으로 고정한다.
             vm.ApplyQuota(
             [
-                Bucket("gemini-weekly", 0.80),   // 20% 사용
-                Bucket("3p-5h",         0.10),   // 90% 사용
-                Bucket("gemini-5h",     0.50),   // 50% 사용
+                Bucket("gemini-weekly", 0.80, window: "weekly"),   // 20% 사용
+                Bucket("3p-5h",         0.10, window: "5h"),       // 90% 사용
+                Bucket("gemini-5h",     0.50, window: "5h"),       // 50% 사용
+                Bucket("3p-weekly",     0.30, window: "weekly"),   // 70% 사용
             ], null, null);
 
-            Assert.Equal(["3p-5h", "gemini-5h", "gemini-weekly"], vm.Models.Select(m => m.ModelId));
+            // 그룹은 서버가 준 순서(gemini → 3p)를 지키고, 그 안에서 5시간 → 주간.
+            Assert.Equal(
+                ["gemini-5h", "gemini-weekly", "3p-5h", "3p-weekly"],
+                vm.Models.Select(m => m.ModelId));
+        }
+    }
+
+    [Fact]
+    public void ApplyQuota_PutsUnknownWindowLast_WithoutDroppingIt()
+    {
+        var vm = CreateVm(out var monitor);
+        using (monitor)
+        {
+            // 새 창 종류는 길이를 몰라 시간선을 못 그린다 — 자리를 지어내지 않고 그룹 맨 뒤로 보낸다.
+            vm.ApplyQuota(
+            [
+                Bucket("gemini-monthly", 0.50, window: "monthly"),
+                Bucket("gemini-weekly",  0.50, window: "weekly"),
+                Bucket("gemini-5h",      0.50, window: "5h"),
+            ], null, null);
+
+            Assert.Equal(
+                ["gemini-5h", "gemini-weekly", "gemini-monthly"],
+                vm.Models.Select(m => m.ModelId));
+        }
+    }
+
+    [Fact]
+    public void ApplyQuota_WritesSummaryLine_LikeClaudeAndCodexGauges()
+    {
+        var previous = Loc.CurrentLang;
+        var vm = CreateVm(out var monitor);
+        using (monitor)
+        {
+            try
+            {
+                Loc.SetLanguage("ko");
+                vm.ApplyQuota([Bucket("gemini-5h", 0.25, window: "5h")], null, null);
+
+                // 게이지 아래 한 줄은 다른 provider 와 같은 문구 형식이어야 한다.
+                Assert.Equal(Loc.UsageSummary(0.75), vm.Models[0].Summary);
+            }
+            finally
+            {
+                Loc.SetLanguage(previous);
+            }
         }
     }
 
@@ -341,11 +389,37 @@ public sealed class AntigravityApplyQuotaTests
         var vm = CreateVm(out var monitor);
         using (monitor)
         {
-            vm.ApplyQuota([Bucket("3p-5h", 0.5)], null, null);
+            vm.ApplyQuota([Bucket("3p-5h", 0.5, window: "5h")], null, null);
 
-            // 이름이 긴 행이라 한 줄 라벨에는 남은 시간만 적고, 절대 시각은 툴팁으로 뺀다.
+            // 행 이름이 "그룹 · 창"이라 한 줄 라벨에 절대 시각까지 넣으면 이름이 잘린다 — 툴팁으로 뺀다.
             Assert.DoesNotContain("(", vm.Models[0].ResetAtLabel);
-            Assert.Contains("(", vm.Models[0].ResetTooltip);
+            Assert.Contains("(", vm.Models[0].PaceTip);
+        }
+    }
+
+    [Fact]
+    public void ApplyQuota_WritesPaceTip_ForTheGaugeTooltip()
+    {
+        var vm = CreateVm(out var monitor);
+        using (monitor)
+        {
+            var now = DateTimeOffset.Now;
+            vm.ApplyQuota(
+            [
+                new AntigravityModelQuota
+                {
+                    ModelId = "3p-5h", TokenType = "5h",
+                    RemainingFraction = 0.4, ResetTime = now.AddHours(2.5),
+                },
+            ], null, null);
+
+            vm.UpdateTimeProgress(now);
+
+            // 툴팁 첫 줄은 Claude·Codex 와 같은 페이스 문구다 (시간 50% 경과 · 사용 60%).
+            var lines = vm.Models[0].PaceTip.Split('\n');
+            Assert.Equal(Loc.PaceTip(0.5, 0.6, settled: true), lines[0]);
+            // 둘째 줄에 절대 시각이 남는다.
+            Assert.Contains("(", lines[1]);
         }
     }
 

--- a/ClaudeUsageTray.Tests/ViewModels/MainViewModelIntegrationTests.cs
+++ b/ClaudeUsageTray.Tests/ViewModels/MainViewModelIntegrationTests.cs
@@ -240,6 +240,17 @@ public class MainViewModelIntegrationTests
                 Assert.Equal(2, markers.Count);
                 Assert.Equal(1, markers.Count(m => m.Visibility == System.Windows.Visibility.Visible));
                 Assert.Equal(1, markers.Count(m => m.Visibility == System.Windows.Visibility.Collapsed));
+
+                // 게이지 아래 요약 한 줄 — Claude·Codex 게이지와 같은 자리·같은 문구.
+                var texts = FindChildren<System.Windows.Controls.TextBlock>(list)
+                    .Select(t => t.Text)
+                    .ToList();
+                Assert.Contains(Loc.UsageSummary(0.6), texts);
+                Assert.Contains(Loc.UsageSummary(0.9), texts);
+
+                // 하단 안내·출처도 다른 provider 상세와 같은 자리에 있다.
+                var note = Assert.IsType<System.Windows.Controls.TextBlock>(popup.FindName("AntigravityNoteText"));
+                Assert.Equal(Loc.ProviderAntigravityNote, note.Text);
             }
             finally
             {

--- a/ClaudeUsageTray/ClaudeUsageTray.csproj
+++ b/ClaudeUsageTray/ClaudeUsageTray.csproj
@@ -7,8 +7,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>1.39.1</Version>
-    <AssemblyVersion>1.39.1</AssemblyVersion>
+    <Version>1.39.2</Version>
+    <AssemblyVersion>1.39.2</AssemblyVersion>
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>false</SelfContained>

--- a/ClaudeUsageTray/Services/LocalizationService.cs
+++ b/ClaudeUsageTray/Services/LocalizationService.cs
@@ -99,6 +99,15 @@ public static class Loc
         _ => "Based on ChatGPT plan · local Codex session data"
     };
 
+    /// <summary>Antigravity 상세 하단 안내 — Codex·OpenCode 의 같은 자리 문구와 같은 톤.</summary>
+    public static string ProviderAntigravityNote => Lang switch
+    {
+        "ko" => "Google 계정 할당량 기준 · Antigravity 공식 수치",
+        "zh" => "基于 Google 账号配额 · Antigravity 官方数据",
+        "ja" => "Google アカウントの割当基準 · Antigravity 公式数値",
+        _ => "Based on the Google account quota · official Antigravity figures"
+    };
+
     public static string ProviderGeminiCliNote => Lang switch
     {
         "ko" => "Gemini CLI 로컬 기준 · 공식 수치 아님",

--- a/ClaudeUsageTray/Services/UsageCalculator.cs
+++ b/ClaudeUsageTray/Services/UsageCalculator.cs
@@ -96,6 +96,14 @@ public static class UsageCalculator
     }
 
     /// <summary>
+    /// 경과 시간이 최소 기준 이상이어야 페이스(빠름/여유 판정, 초과색)를 신뢰할 수 있다고 본다.
+    /// 창 초반 1~2분 사용이 "거의 전부 초과"로 과장돼 보이는 것을 막는다.
+    /// 진행률을 모르면(창 밖) 페이스도 판정하지 않는다.
+    /// </summary>
+    public static bool IsPaceSettled(double? timeProgress, TimeSpan window, TimeSpan minElapsed)
+        => timeProgress is double progress && progress * window.TotalSeconds >= minElapsed.TotalSeconds;
+
+    /// <summary>
     /// 응답의 window_minutes 를 창 길이로 변환한다. 길이를 모르면 <paramref name="fallback"/>.
     /// Codex 는 플랜/계정에 따라 창이 5시간이 아니라 주간일 수 있어, 길이를 하드코딩하면
     /// 시간 진행률이 음수로 나와 0 으로 잘리고(=시간선이 왼쪽 끝에 붙어 안 보임) 만다.

--- a/ClaudeUsageTray/ViewModels/AntigravityViewModel.cs
+++ b/ClaudeUsageTray/ViewModels/AntigravityViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using ClaudeUsageTray.Models;
 using ClaudeUsageTray.Services;
@@ -117,14 +118,14 @@ public partial class AntigravityViewModel : ObservableObject
                 ModelId = m.ModelId,
                 DisplayName = ResolveDisplayName(m),
                 UsagePercent = used,
+                Summary = Loc.UsageSummary(used),
                 ResetAt = m.ResetTime,
                 Window = ResolveWindowLength(m),
             };
             row.UpdateTimeProgress(now);
             rows.Add(row);
         }
-        rows.Sort((a, b) => b.UsagePercent.CompareTo(a.UsagePercent));
-        Models = rows;
+        Models = SortLikeOtherProviders(rows, models);
 
         // 창마다 한도가 따로 걸리므로 평균은 가장 급한 제약을 가린다 (주간 90% + 5시간 0% → 45%).
         // 트레이 게이지에는 가장 많이 쓴 창을 올린다.
@@ -139,6 +140,37 @@ public partial class AntigravityViewModel : ObservableObject
     {
         foreach (var row in Models)
             row.UpdateTimeProgress(now);
+    }
+
+    /// <summary>
+    /// 게이지 순서를 Claude·Codex 와 맞춘다 — 짧은 창(5시간)이 위, 긴 창(주간)이 아래.
+    /// 사용량 내림차순으로 세우면 새로고침마다 순서가 뒤바뀌어 같은 자리를 눈으로 좇을 수 없고,
+    /// 다른 provider 는 창 길이 순으로 고정돼 있어 같은 화면에서 읽는 방식이 달라진다.
+    ///
+    /// 그룹(Gemini · Claude·GPT)끼리는 서버가 준 순서를 지켜 같은 그룹의 두 창이 붙어 보이게 한다.
+    /// 창 길이를 모르는 행(새 창 종류)은 맨 뒤로 — 자리를 지어내지 않는다.
+    /// </summary>
+    private static IReadOnlyList<AntigravityModelRow> SortLikeOtherProviders(
+        List<AntigravityModelRow> rows, IReadOnlyList<AntigravityModelQuota> source)
+    {
+        var groupOrder = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var quota in source)
+        {
+            var key = GroupKey(quota.ModelId);
+            if (!groupOrder.ContainsKey(key))
+                groupOrder[key] = groupOrder.Count;
+        }
+
+        return [.. rows
+            .OrderBy(r => groupOrder.TryGetValue(GroupKey(r.ModelId), out var i) ? i : int.MaxValue)
+            .ThenBy(r => r.Window ?? TimeSpan.MaxValue)];
+    }
+
+    /// <summary>버킷 식별자에서 창 종류를 뗀 앞부분이 모델 그룹이다 ("gemini-weekly" → "gemini").</summary>
+    private static string GroupKey(string modelId)
+    {
+        var dash = modelId.LastIndexOf('-');
+        return dash > 0 ? modelId[..dash] : modelId;
     }
 
     /// <summary>
@@ -220,17 +252,23 @@ public sealed partial class AntigravityModelRow : ObservableObject
     public double UsagePercent { get; init; }        // 0..1
     public DateTimeOffset? ResetAt { get; init; }
 
+    /// <summary>게이지 아래 한 줄 요약 ("70% 사용 · 잔량 30%") — Claude·Codex 게이지와 같은 자리.</summary>
+    public string Summary { get; init; } = "";
+
     /// <summary>창 길이. 모르면 null — 시간선 마커를 그리지 않는다.</summary>
     public TimeSpan? Window { get; init; }
 
     [ObservableProperty] private string _resetAtLabel = "";
 
     /// <summary>
-    /// 게이지 툴팁 — 절대 시각까지 적는다.
-    /// 이름이 긴 행이라(그룹 × 창) 한 줄 라벨에 절대 시각까지 넣으면 이름이 잘린다.
-    /// 다른 provider 의 설정(ShowAbsoluteResetTime)과 달리 여기서는 툴팁 자리를 쓴다.
+    /// 게이지 툴팁 — 첫 줄은 Claude·Codex 게이지 툴팁과 같은 페이스 문구,
+    /// 둘째 줄은 리셋 절대 시각이다.
+    ///
+    /// 절대 시각을 다른 provider 처럼 한 줄 라벨에 붙이지 않는 이유: 이 행의 이름은 "그룹 · 창"이라
+    /// 320px 팝업에서 절대 시각까지 넣으면 이름이 "Gemini 모..." 로 잘려 어느 창인지 구분되지 않는다.
+    /// (다른 provider 의 행 이름은 "주간 윈도우" 한 덩어리라 같은 문제가 없다.)
     /// </summary>
-    [ObservableProperty] private string _resetTooltip = "";
+    [ObservableProperty] private string _paceTip = "";
 
     [ObservableProperty] private bool _hasTimeline = false;
     [ObservableProperty] private double _timePercent = 0.0;
@@ -238,9 +276,15 @@ public sealed partial class AntigravityModelRow : ObservableObject
     internal void UpdateTimeProgress(DateTimeOffset now)
     {
         ResetAtLabel = UsageCalculator.FormatResetLabel(ResetAt, false, false, now);
-        ResetTooltip = UsageCalculator.FormatResetLabel(ResetAt, false, true, now);
-        var progress = UsageCalculator.TimeProgress(ResetAt, Window ?? TimeSpan.Zero, now);
+
+        var window = Window ?? TimeSpan.Zero;
+        var progress = UsageCalculator.TimeProgress(ResetAt, window, now);
         HasTimeline = progress.HasValue;
         TimePercent = progress ?? 0;
+        // 창 초반에는 페이스 판정을 유보한다 — 하한은 Codex 와 같은 창 길이의 1/60(5시간→5분, 주간→2.8시간).
+        var pace = Loc.PaceTip(progress, UsagePercent,
+            UsageCalculator.IsPaceSettled(progress, window, window / 60));
+        var absolute = UsageCalculator.FormatResetLabel(ResetAt, false, true, now);
+        PaceTip = string.IsNullOrEmpty(absolute) ? pace : $"{pace}\n{absolute.TrimStart(' ', '·')}";
     }
 }

--- a/ClaudeUsageTray/ViewModels/MainViewModel.cs
+++ b/ClaudeUsageTray/ViewModels/MainViewModel.cs
@@ -137,6 +137,9 @@ namespace ClaudeUsageTray.ViewModels;
         System.Array.Empty<AntigravityModelRow>();
     [ObservableProperty] private bool _isAntigravityEnabled = true;
     [ObservableProperty] private double _antigravityPercent = 0.0;
+    // 상세 하단 안내 + 출처 — Codex 상세의 같은 자리(왼쪽 안내 / 오른쪽 출처)와 같은 구성.
+    [ObservableProperty] private string _antigravityNote = Loc.ProviderAntigravityNote;
+    [ObservableProperty] private string _antigravityDataSource = "";
 
     /// <summary>플랜 배지 문구 — Codex 의 플랜 라벨과 같은 자리에 쓴다. 요금제 이름이 없으면 tier 이름으로 대신한다.</summary>
     public string AntigravityPlanLabel =>
@@ -2603,10 +2606,9 @@ namespace ClaudeUsageTray.ViewModels;
             IsPaceSettled(longTime, _rawCodexLongWindow, _rawCodexLongWindow / 60));
     }
 
-    // 경과 시간이 최소 기준 이상이어야 페이스(초과색/빠름·여유)를 신뢰할 수 있다고 본다.
-    // 진행률을 모르면(창 밖) 페이스도 판정하지 않는다.
+    // 페이스 판정 기준은 Antigravity 행(AntigravityModelRow)도 같이 쓰므로 UsageCalculator 에 둔다.
     private static bool IsPaceSettled(double? timeProgress, TimeSpan window, TimeSpan minElapsed)
-        => timeProgress is double progress && progress * window.TotalSeconds >= minElapsed.TotalSeconds;
+        => UsageCalculator.IsPaceSettled(timeProgress, window, minElapsed);
 
     /// <summary>
     /// ShowAbsoluteResetTime 토글 시 4개 reset 라벨을 raw 값에서 즉시 재포맷.
@@ -2766,6 +2768,8 @@ namespace ClaudeUsageTray.ViewModels;
             AntigravityVm.RefreshLocalizedLabels();
             // 행 객체가 새로 만들어지므로 미러 프로퍼티도 다시 가리켜야 화면이 바뀐다.
             AntigravityModels = AntigravityVm.Models;
+            // 안내 문구는 값이 필드에 담겨 있어 다시 넣어야 바뀐다(다음 조회까지 기다리지 않도록).
+            AntigravityNote = Loc.ProviderAntigravityNote;
             OnPropertyChanged(string.Empty);
         });
     }
@@ -2791,6 +2795,9 @@ namespace ClaudeUsageTray.ViewModels;
 
         await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
         {
+            AntigravityNote = Loc.ProviderAntigravityNote;
+            AntigravityDataSource = "";
+
             // 이 PC 에서 Antigravity 에 로그인하지 않았거나 조회가 실패하면 다른 PC 가 올린 값으로 채운다.
             // 할당량은 구글 계정 단위라 어느 PC 에서 받아도 같은 값이다.
             if (!AntigravityVm.HasData && remoteQuota is { Quota.HasData: true } snapshot)
@@ -2799,6 +2806,11 @@ namespace ClaudeUsageTray.ViewModels;
                     ToAntigravityModelQuotas(snapshot.Quota!.Models),
                     snapshot.Quota.TierName,
                     snapshot.Quota.PaidTierName);
+
+                // 다른 PC 의 값을 보고 있다는 것은 Codex 와 같은 자리(오른쪽 출처)에 적는다.
+                AntigravityDataSource = Loc.UsageSyncQuotaFromDevice(
+                    snapshot.DeviceName,
+                    (snapshot.Quota.ObservedAtUtc ?? snapshot.ObservedAtUtc).ToLocalTime().ToString("HH:mm"));
             }
 
             AntigravityHasData = AntigravityVm.HasData;

--- a/ClaudeUsageTray/ViewModels/MainViewModel.cs
+++ b/ClaudeUsageTray/ViewModels/MainViewModel.cs
@@ -140,6 +140,8 @@ namespace ClaudeUsageTray.ViewModels;
     // 상세 하단 안내 + 출처 — Codex 상세의 같은 자리(왼쪽 안내 / 오른쪽 출처)와 같은 구성.
     [ObservableProperty] private string _antigravityNote = Loc.ProviderAntigravityNote;
     [ObservableProperty] private string _antigravityDataSource = "";
+    // 출처 문구는 언어가 바뀌면 다시 만들어야 하므로 완성된 문장 대신 재료(기기·관측 시각)를 들고 있는다.
+    private (string Device, DateTimeOffset ObservedAt)? _antigravityQuotaOrigin;
 
     /// <summary>플랜 배지 문구 — Codex 의 플랜 라벨과 같은 자리에 쓴다. 요금제 이름이 없으면 tier 이름으로 대신한다.</summary>
     public string AntigravityPlanLabel =>
@@ -2768,8 +2770,9 @@ namespace ClaudeUsageTray.ViewModels;
             AntigravityVm.RefreshLocalizedLabels();
             // 행 객체가 새로 만들어지므로 미러 프로퍼티도 다시 가리켜야 화면이 바뀐다.
             AntigravityModels = AntigravityVm.Models;
-            // 안내 문구는 값이 필드에 담겨 있어 다시 넣어야 바뀐다(다음 조회까지 기다리지 않도록).
+            // 안내·출처 문구는 값이 필드에 담겨 있어 다시 만들어야 바뀐다(다음 조회까지 기다리지 않도록).
             AntigravityNote = Loc.ProviderAntigravityNote;
+            RefreshAntigravityDataSourceLabel();
             OnPropertyChanged(string.Empty);
         });
     }
@@ -2796,7 +2799,7 @@ namespace ClaudeUsageTray.ViewModels;
         await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
         {
             AntigravityNote = Loc.ProviderAntigravityNote;
-            AntigravityDataSource = "";
+            _antigravityQuotaOrigin = null;
 
             // 이 PC 에서 Antigravity 에 로그인하지 않았거나 조회가 실패하면 다른 PC 가 올린 값으로 채운다.
             // 할당량은 구글 계정 단위라 어느 PC 에서 받아도 같은 값이다.
@@ -2808,10 +2811,11 @@ namespace ClaudeUsageTray.ViewModels;
                     snapshot.Quota.PaidTierName);
 
                 // 다른 PC 의 값을 보고 있다는 것은 Codex 와 같은 자리(오른쪽 출처)에 적는다.
-                AntigravityDataSource = Loc.UsageSyncQuotaFromDevice(
+                _antigravityQuotaOrigin = (
                     snapshot.DeviceName,
-                    (snapshot.Quota.ObservedAtUtc ?? snapshot.ObservedAtUtc).ToLocalTime().ToString("HH:mm"));
+                    snapshot.Quota.ObservedAtUtc ?? snapshot.ObservedAtUtc);
             }
+            RefreshAntigravityDataSourceLabel();
 
             AntigravityHasData = AntigravityVm.HasData;
             AntigravityHasError = AntigravityVm.HasError;
@@ -2861,6 +2865,15 @@ namespace ClaudeUsageTray.ViewModels;
             return null;
         }
     }
+
+    /// <summary>
+    /// 출처 문구를 현재 언어로 만든다. 다른 PC 값을 보고 있지 않으면 빈 문자열 —
+    /// 로컬 조회 결과에는 "어디서 왔는지" 적을 것이 없다.
+    /// </summary>
+    private void RefreshAntigravityDataSourceLabel() =>
+        AntigravityDataSource = _antigravityQuotaOrigin is { } origin
+            ? Loc.UsageSyncQuotaFromDevice(origin.Device, origin.ObservedAt.ToLocalTime().ToString("HH:mm"))
+            : "";
 
     private static UsageSyncQuotaSnapshot? CreateAntigravityQuotaSnapshot(AntigravitySnapshot snapshot)
     {

--- a/ClaudeUsageTray/Views/UsagePopup.xaml
+++ b/ClaudeUsageTray/Views/UsagePopup.xaml
@@ -1251,8 +1251,8 @@
                             </Grid>
                         </Button>
 
-                        <!-- Detail body — focused 일 때만. 다른 provider 와 같은 구조:
-                             플랜 배지 → (제목 · 퍼센트 · 리셋) 한 줄 → 게이지 + 시간선 마커 -->
+                        <!-- Detail body — focused 일 때만. Codex·Claude 상세와 같은 구조:
+                             플랜 배지 → (제목 · 퍼센트 · 리셋) 한 줄 → 게이지 + 시간선 마커 → 요약 한 줄 → 하단 안내·출처 -->
                         <StackPanel Margin="10,6,10,0" Visibility="{Binding IsAntigravityFocused, Converter={StaticResource BoolToVisibility}}">
                             <!-- 플랜 배지 — Codex 의 플랜 라벨과 같은 자리·같은 톤 -->
                             <TextBlock x:Name="AntigravityPlanBadge"
@@ -1260,11 +1260,11 @@
                                        TextWrapping="Wrap"
                                        Visibility="{Binding AntigravityPlanLabel, Converter={StaticResource StringToVisibility}}"/>
 
-                            <!-- 창별 게이지 (그룹 × 주간·5시간) -->
+                            <!-- 창별 게이지 (그룹 × 5시간·주간 — 짧은 창이 위, Claude·Codex 와 같은 순서) -->
                             <ItemsControl x:Name="AntigravityGaugeList" ItemsSource="{Binding AntigravityModels}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <StackPanel Margin="0,0,0,10">
+                                        <StackPanel>
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="*"/>
@@ -1280,7 +1280,7 @@
                                                 </StackPanel>
                                             </Grid>
                                             <!-- 시간선 마커: 창 진행률 위치에 세로선 (주간 7일 / 5시간 창 기준) -->
-                                            <Grid Height="8" Margin="0,4,0,0" ToolTip="{Binding ResetTooltip}">
+                                            <Grid Height="8" Margin="0,4,0,0" ToolTip="{Binding PaceTip}">
                                                 <ProgressBar Value="{Binding UsagePercent}" Maximum="1" Style="{StaticResource AntigravityBarStyle}" VerticalAlignment="Center"/>
                                                 <Grid VerticalAlignment="Center" Height="8">
                                                     <Grid.ColumnDefinitions>
@@ -1291,6 +1291,8 @@
                                                             Visibility="{Binding HasTimeline, Converter={StaticResource BoolToVisibility}}"/>
                                                 </Grid>
                                             </Grid>
+                                            <!-- 요약 한 줄 — Codex·Claude 게이지 아래와 같은 자리·같은 문구 형식 -->
+                                            <TextBlock Text="{Binding Summary}" Foreground="#8B92B3" FontSize="10" Margin="0,4,0,10"/>
                                         </StackPanel>
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
@@ -1298,6 +1300,12 @@
 
                             <TextBlock Text="{Binding AntigravityErrorMessage}" Foreground="#EF4444" FontSize="10" TextWrapping="Wrap" Margin="0,2,0,0"
                                        Visibility="{Binding AntigravityHasError, Converter={StaticResource BoolToVisibility}}"/>
+
+                            <!-- 하단 안내(왼쪽) · 출처(오른쪽) — Codex 상세 하단과 같은 구성 -->
+                            <Grid Margin="0,0,0,0">
+                                <TextBlock x:Name="AntigravityNoteText" Text="{Binding AntigravityNote}" Foreground="#5A5F7A" FontSize="10" HorizontalAlignment="Left"/>
+                                <TextBlock x:Name="AntigravityDataSourceText" Text="{Binding AntigravityDataSource}" Foreground="#3D4266" FontSize="9" HorizontalAlignment="Right" VerticalAlignment="Bottom"/>
+                            </Grid>
                         </StackPanel>
                     </StackPanel>
                 </StackPanel>


### PR DESCRIPTION
## 문제

Antigravity 상세가 아직 다른 에이전트와 달라 보였습니다.

- 네 칸이 **사용량 내림차순**으로 세워져 새로고침마다 자리가 바뀌고, 5시간·주간이 섞여 나왔습니다. Claude·Codex 는 짧은 창이 항상 위입니다.
- 게이지 아래 `45% 사용 · 잔량 55%` 요약 한 줄이 없었습니다.
- 게이지 툴팁이 리셋 시각만 보여줘, Claude·Codex 의 페이스 문구(`시간 50% 경과 · 사용 45% · 5%p 여유`)와 달랐습니다.
- 상세 맨 아래 데이터 출처 안내가 없어 섹션이 게이지에서 끊겼습니다.

## 변경

- 정렬을 **모델 그룹(서버 순서) × 창 길이(5시간 → 주간)** 로 고정. 창 길이를 모르는 행은 맨 뒤.
- 게이지 아래 요약 한 줄 추가 (`Loc.UsageSummary` — Claude·Codex 와 같은 문구).
- 게이지 툴팁을 `Loc.PaceTip` 으로 통일하고 리셋 절대 시각은 둘째 줄로.
- 상세 하단에 안내(왼쪽) · 출처(오른쪽) 추가. 다른 PC 가 올린 값을 보고 있으면 그 기기와 관측 시각을 적습니다.
- `IsPaceSettled` 를 `UsageCalculator` 로 옮겨 Codex 와 같은 하한(창 길이의 1/60)을 쓰게 했습니다.

### 절대 시각을 라벨에 넣지 않은 이유

`ShowAbsoluteResetTime` 을 켠 상태로 렌더해 보니 행 이름이 `Gemini 모...` 로 잘렸습니다. 이 행의 이름은 `그룹 · 창`(예: `Gemini 모델 · 5시간`)이라 320px 폭에서 절대 시각까지 한 줄에 들어가지 않고, 잘리면 **어느 창인지 구분 자체가 안 됩니다**. 다른 provider 는 이름이 `주간 윈도우` 한 덩어리라 같은 문제가 없습니다. 그래서 절대 시각은 툴팁 둘째 줄에 남겼습니다.

## 검증

- `dotnet test` 379개 전부 통과.
- 팝업을 오프스크린으로 실제 렌더해 Codex 상세와 나란히 눈으로 비교했습니다(순서·요약·시간선·안내 위치 일치 확인).
- 팝업 구조 테스트(`UsagePopup_AntigravityQuotaUsesTheSameFlatGaugeStructureAsOtherProviders`)에 요약 줄·하단 안내 단정을 추가했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)